### PR TITLE
Pubmed timeout fix

### DIFF
--- a/src/main/java/reciter/pubmed/callable/PubMedUriParserCallable.java
+++ b/src/main/java/reciter/pubmed/callable/PubMedUriParserCallable.java
@@ -22,7 +22,7 @@ public class PubMedUriParserCallable implements Callable<List<PubMedArticle>> {
     private final SAXParser saxParser;
     private final InputSource inputSource;
 
-    public List<PubMedArticle> parse(InputSource inputSource) throws SAXException, IOException {
+    public synchronized List<PubMedArticle> parse(InputSource inputSource) throws SAXException, IOException {
         inputSource = preprocessSpecialCharacters(inputSource);
         saxParser.parse(inputSource, xmlHandler);
         return xmlHandler.getPubmedArticles();

--- a/src/main/java/reciter/pubmed/model/PubmedESearchResult.java
+++ b/src/main/java/reciter/pubmed/model/PubmedESearchResult.java
@@ -1,0 +1,24 @@
+package reciter.pubmed.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonRootName;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+//@JsonRootName(value = "esearchresult")
+public class PubmedESearchResult {
+	
+	@JsonProperty(value = "count", required = true)
+	private int count;
+	@JsonProperty(value = "retmax", required = true)
+	private int retMax;
+	@JsonProperty(value = "retstart", required = true)
+	private int retStart;
+	@JsonProperty(value = "querykey", required = true)
+	private int queryKey;
+	@JsonProperty(value = "webenv", required = true)
+	private String webenv;
+}

--- a/src/main/java/reciter/pubmed/querybuilder/PubmedXmlQuery.java
+++ b/src/main/java/reciter/pubmed/querybuilder/PubmedXmlQuery.java
@@ -75,7 +75,7 @@ public class PubmedXmlQuery {
     /**
      * Returned format for query. xml or json.
      */
-    private String retMode = "xml";
+    private String retMode = "json";
 
     public PubmedXmlQuery() {
     }
@@ -97,7 +97,15 @@ public class PubmedXmlQuery {
     public String buildESearchQuery() {
         StringBuilder sb = new StringBuilder();
         sb.append(ESEARCH_BASE_URL);
-        sb.append("?db=");
+        if(apiKey != null) {
+    		if(!apiKey.isEmpty()) {
+	        sb.append("?api_key=");
+	        sb.append(apiKey);
+	        sb.append("&db=");
+    		}
+        } else {
+        	sb.append("?db=");
+        }
         sb.append(db);
         sb.append("&term=");
         sb.append(term);
@@ -107,12 +115,7 @@ public class PubmedXmlQuery {
         sb.append(useHistory);
         sb.append("&retmode=");
         sb.append(retMode);
-        if(apiKey != null) {
-	    		if(!apiKey.isEmpty()) {
-		        sb.append("&api_key=");
-		        sb.append(apiKey);
-	    		}
-        }
+        
         return sb.toString();
     }
 
@@ -125,7 +128,15 @@ public class PubmedXmlQuery {
     public String buildEFetchQuery() {
         StringBuilder sb = new StringBuilder();
         sb.append(EFETCH_BASE_URL);
-        sb.append("?db=");
+        if(apiKey != null) {
+    		if(!apiKey.isEmpty()) {
+	        sb.append("?api_key=");
+	        sb.append(apiKey);
+	        sb.append("&db=");
+    		}
+        } else {
+        	sb.append("?db=");
+        }
         sb.append(db);
         sb.append("&query_key=");
         sb.append(queryKey);
@@ -134,15 +145,10 @@ public class PubmedXmlQuery {
         sb.append("&retmax=");
         sb.append(retMax);
         sb.append("&retmode=");
-        sb.append(retMode);               
+        sb.append("xml");               
         sb.append("&WebEnv=");
         sb.append(webEnv);
-        if(apiKey != null) {
-        		if(!apiKey.isEmpty()) {
-		        sb.append("&api_key=");
-		        sb.append(apiKey);
-        		}
-        }
+        
         return sb.toString();
     }
 }


### PR DESCRIPTION
Pubmed allows only 3 calls per second based on an IP which is used as api-key when no api_key is added as queryParam but 10 calls per second when added an api_key.
- Added fix to check for response header for `X-RateLimit-Remaining` and `Retry-After` and call the api after retry-After
- Removed all thread delays
- Switched to json as response for esearch from xml
- Added json model for the same
- Added synchronized to method for parse using callables 


Reference - https://github.com/ropensci/taxize/issues/722#issuecomment-443549271