### PR TITLE
Pubmed eFetch Api too many request fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,6 +91,11 @@
         		</exclusion>
         	</exclusions>
         </dependency>
+        <dependency>
+      		<groupId>com.github.rholder</groupId>
+      		<artifactId>guava-retrying</artifactId>
+      		<version>2.0.0</version>
+    	</dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/reciter/pubmed/callable/PubMedUriParserCallable.java
+++ b/src/main/java/reciter/pubmed/callable/PubMedUriParserCallable.java
@@ -23,12 +23,13 @@ public class PubMedUriParserCallable implements Callable<List<PubMedArticle>> {
     private final InputSource inputSource;
 
     public List<PubMedArticle> parse(InputSource inputSource) throws SAXException, IOException {
-        inputSource = preprocessSpecialCharacters(inputSource);
+        //inputSource = preprocessSpecialCharacters(inputSource);
         saxParser.parse(inputSource, xmlHandler);
         return xmlHandler.getPubmedArticles();
     }
 
     public List<PubMedArticle> call() throws Exception {
+    	InputSource inputSource = preprocessSpecialCharacters(this.inputSource);
         return parse(inputSource);
     }
 

--- a/src/main/java/reciter/pubmed/retriever/PubMedArticleRetrievalService.java
+++ b/src/main/java/reciter/pubmed/retriever/PubMedArticleRetrievalService.java
@@ -22,6 +22,12 @@ import org.xml.sax.SAXException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.rholder.retry.RetryException;
+import com.github.rholder.retry.Retryer;
+import com.github.rholder.retry.RetryerBuilder;
+import com.github.rholder.retry.StopStrategies;
+import com.github.rholder.retry.WaitStrategies;
+import com.google.common.base.Predicates;
 
 import reciter.model.pubmed.PubMedArticle;
 import reciter.pubmed.callable.PubMedUriParserCallable;
@@ -39,6 +45,7 @@ import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -119,9 +126,26 @@ public class PubMedArticleRetrievalService {
                 // Use the webenv value to retrieve xml.
                 String eFetchUrl = pubmedXmlQuery.buildEFetchQuery();
                 log.info("eFetchUrl=[{}].", eFetchUrl);
+                
+                
 
                 try {
-					callables.add(new PubMedUriParserCallable(new PubmedEFetchHandler(), getSaxParser(), new InputSource(eFetchUrl)));
+                	PubMedUriParserCallable callable = new PubMedUriParserCallable(new PubmedEFetchHandler(), getSaxParser(), new InputSource(eFetchUrl));
+                	Retryer<List<PubMedArticle>> retryer = RetryerBuilder.<List<PubMedArticle>>newBuilder()
+                            .retryIfResult(Predicates.<List<PubMedArticle>>isNull())
+                            .retryIfExceptionOfType(IOException.class)
+                            .retryIfRuntimeException()
+                            .withWaitStrategy(WaitStrategies.fixedWait(2L, TimeUnit.SECONDS))
+                            .withStopStrategy(StopStrategies.stopAfterAttempt(3))
+                            .build();
+                    try {
+                        retryer.call(callable);
+                    } catch (RetryException e) {
+                    	log.error("RetryException", e);
+                    } catch (ExecutionException e) {
+                    	log.error("ExecutionException", e);
+                    }
+					callables.add(callable);
 				} catch (ParserConfigurationException | SAXException e) {
 					log.error("Exception", e);
 				}

--- a/src/main/java/reciter/pubmed/retriever/PubMedArticleRetrievalService.java
+++ b/src/main/java/reciter/pubmed/retriever/PubMedArticleRetrievalService.java
@@ -26,6 +26,7 @@ import com.github.rholder.retry.RetryException;
 import com.github.rholder.retry.Retryer;
 import com.github.rholder.retry.RetryerBuilder;
 import com.github.rholder.retry.StopStrategies;
+import com.github.rholder.retry.StopStrategy;
 import com.github.rholder.retry.WaitStrategies;
 import com.google.common.base.Predicates;
 
@@ -135,8 +136,7 @@ public class PubMedArticleRetrievalService {
                             .retryIfResult(Predicates.<List<PubMedArticle>>isNull())
                             .retryIfExceptionOfType(IOException.class)
                             .retryIfRuntimeException()
-                            .withWaitStrategy(WaitStrategies.fixedWait(2L, TimeUnit.SECONDS))
-                            .withStopStrategy(StopStrategies.stopAfterAttempt(3))
+                            .withWaitStrategy(WaitStrategies.fibonacciWait(100L, 2L, TimeUnit.MINUTES))
                             .build();
                     try {
                         retryer.call(callable);


### PR DESCRIPTION
- Implemented guava-retrying - https://github.com/rholder/guava-retrying
- Added fibonacci wait retry up to 2 minutes increasing with a multiplier of 100
- Currently using noStop strategy as default