### PR TITLE
Prepare for release of 1.1.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11-jre-slim
+FROM adoptopenjdk/openjdk11:alpine-jre
 
 RUN mkdir -p /app
 WORKDIR /app

--- a/README.md
+++ b/README.md
@@ -26,6 +26,14 @@ This tool has several advantages over using the eFetch API.
 - Even if your machine make calls that don’t exceed the published allowable calls per second, NCBI will inexplicably throttle requests. This application checks the `X-RateLimit-Remaining` and `Retry-After` response headers, and calls the API after the `retry-After` value.
 
 
+## Prerequisites
+
+- Java 11
+- Latest version of Maven. To install Maven navigate to the directory where ReCiter PubMed Retrieval Tool will be installed, execute `brew install maven` and then `mvn clean install`
+If you want to use Java 8 then update `<java.version>1.8</java.version>` in [pom.xml](https://github.com/wcmc-its/ReCiter-PubMed-Retrieval-Tool/blob/f30963755659e5d4cc668297e3c1e7a8d577e259/pom.xml#L20)
+
+It is not necessary to install ReCiter in order to use the API.
+
 
 ## Installing
 
@@ -48,7 +56,7 @@ This tool has several advantages over using the eFetch API.
 - Option #1: Set at the system level using this command `export SERVER_PORT=[your port number]`. This supersedes any ports set in application.properties.
 - Option #2: Update the application.properties file located at `/src/main/resources/` Make sure the port doesn't conflict with other services such as ReCiter or ReCiter PubMed Retrieval Tool.
 7. Build Maven instance `mvn spring-boot:run`
-8. Visit `http://localhost:[your port number]/swagger-ui.html` to see the Swagger page for this service.
+8. Visit `http://localhost:[your port number]/swagger-ui/index.html` or  `http://localhost:[your port number]/swagger-ui/` to see the Swagger page for this service.
 
 ## Obtaining an API key
 

--- a/kubernetes/k8-deployment.yaml
+++ b/kubernetes/k8-deployment.yaml
@@ -44,17 +44,17 @@ spec:
                   name: ENVCONFIG
                   key: SERVER_PORT
             - name: JAVA_OPTIONS
-              value: "-Xmx1100m"
+              value: "-Xmx2000m"
           ports:
             - containerPort: 5000
               name: reciter-pubmed
           resources:
             requests:
-              memory: 1.3G
-              cpu: 0.6
+              memory: 2.5G
+              cpu: 1
             limits:
-              memory: 1.5G
-              cpu: 0.8
+              memory: 2.6G
+              cpu: 1
           livenessProbe:
             httpGet:
               path: "/pubmed/ping"

--- a/src/main/java/reciter/pubmed/model/PubMedQuery.java
+++ b/src/main/java/reciter/pubmed/model/PubMedQuery.java
@@ -64,9 +64,9 @@ public class PubMedQuery {
             //parts.add(author + " [au]");
         	parts.add(author);
         }
-        //Switched from [DP] to [EDAT] for better capture of pubs : Date of publication - Date added to Entrez
+        //Added both [DP] and [EDAT] for better capture of pubs : Date of publication - Date added to Entrez
         if (start != null && end != null) {
-            parts.add("(" + dt.format(start) + "[EDAT]" + ":" + dt.format(end) + "[EDAT])");
+            parts.add("((" + dt.format(start) + ":" + dt.format(end) + "[EDAT]" + ") OR (" + dt.format(start) + ":" + dt.format(end) + "[DP]))");
         }
         if (strategyQuery != null && !strategyQuery.isEmpty()) {
             parts.add(strategyQuery);


### PR DESCRIPTION
This will serve as the release of 1.1.0

- Upgrade to Java 11 from Java 8
- Upgrade to Swagger 3.0. The new url to access swagger will be `<protocol>://<host>:<port>/swagger-ui/index.html`
- Added JAVA_OPTS as environment variable to image to specify max heapsize
- Add healthcheck path for application use `<protocol>://<host>:<port>/pubmed/ping`
- For date range queries [DP] and [EDAT] were added. Meaning publication date that was added to pubmed and publications date added to entrez are both being considered
- ReferenceList was added #28 
- Added orcid identifier for authors #23 
- Upgrade to all dependencies to use latest stable releases
- Codebuild images were also updated to use Java 11