### PR TITLE
Fix SAX parser state leakage when PubmedBookArticle follows PubmedArticle

### DIFF
--- a/src/main/java/reciter/pubmed/xmlparser/PubmedEFetchHandler.java
+++ b/src/main/java/reciter/pubmed/xmlparser/PubmedEFetchHandler.java
@@ -287,6 +287,9 @@ public class PubmedEFetchHandler extends DefaultHandler {
         if (qName.equalsIgnoreCase("PubmedArticle")) {
             pubmedArticle = PubMedArticle.builder().build(); // create a new PubmedArticle.
         }
+        if (qName.equalsIgnoreCase("PubmedBookArticle")) {
+            pubmedArticle = null; // Prevent book article fields from corrupting previous article
+        }
         //This check was introduced for articles which are of book type returning  <PubmedBookArticle> tag
         if (pubmedArticle != null) {
             if (qName.equalsIgnoreCase("MedlineCitation")) {
@@ -424,11 +427,6 @@ public class PubmedEFetchHandler extends DefaultHandler {
             }
             if(qName.equalsIgnoreCase("Identifier") && bAuthorList && isOrcid(attributes)) {
                 bOrcid = true;
-            }
-            if (qName.equalsIgnoreCase("AuthorList") &&
-                    pubmedArticle != null) {
-                pubmedArticle.getMedlinecitation().getArticle().setAuthorlist(new ArrayList<>()); // set the PubmedArticle's MedlineCitation's MedlineCitationArticle's title.
-                bAuthorList = true;
             }
             if (qName.equalsIgnoreCase("Abstract") &&
                     pubmedArticle != null) {


### PR DESCRIPTION
## Summary

- **Bug**: The SAX parser in `PubmedEFetchHandler.java` uses a single instance-level `pubmedArticle` variable. When PubMed returns a batch containing both `<PubmedArticle>` and `<PubmedBookArticle>` elements, there is no handler for `<PubmedBookArticle>`. When a book article follows a regular article, `pubmedArticle` still references the previous article's object. The book article's `<AuthorList>`, `<Abstract>`, and other child elements then overwrite the previous article's data via the still-live reference. The corrupted data gets persisted to DynamoDB.
- **Example**: PMID 38461731 had its 8-author list replaced by 79 authors from book article PMID 41525446.
- **Fix**: Null out `pubmedArticle` when `<PubmedBookArticle>` is encountered, so all subsequent element processing is safely skipped by the existing `if (pubmedArticle != null)` guard.
- **Cleanup**: Removed a duplicate `AuthorList` handler block in `startElement` that redundantly re-initialized the author list.

This is a short-term fix. Long-term plan is to properly parse and support `PubmedBookArticle` types.

## Test plan

- [ ] Verify build compiles (`mvn compile` passes)
- [ ] Test with a PubMed batch that includes both `<PubmedArticle>` and `<PubmedBookArticle>` (e.g., a fetch containing PMIDs 38461731 and 41525446)
- [ ] Confirm the regular article's author list, abstract, and other fields are not overwritten
- [ ] Confirm book articles are silently skipped (not added to the results list)
- [ ] Run existing unit tests to verify no regressions
