### PR TITLE
Fix SAX parser state leakage when PubmedBookArticle follows PubmedArticle

### DIFF
--- a/src/main/java/reciter/pubmed/xmlparser/PubmedEFetchHandler.java
+++ b/src/main/java/reciter/pubmed/xmlparser/PubmedEFetchHandler.java
@@ -287,6 +287,9 @@ public class PubmedEFetchHandler extends DefaultHandler {
         if (qName.equalsIgnoreCase("PubmedArticle")) {
             pubmedArticle = PubMedArticle.builder().build(); // create a new PubmedArticle.
         }
+        if (qName.equalsIgnoreCase("PubmedBookArticle")) {
+            pubmedArticle = null; // Prevent book article fields from corrupting previous article
+        }
         //This check was introduced for articles which are of book type returning  <PubmedBookArticle> tag
         if (pubmedArticle != null) {
             if (qName.equalsIgnoreCase("MedlineCitation")) {
@@ -424,11 +427,6 @@ public class PubmedEFetchHandler extends DefaultHandler {
             }
             if(qName.equalsIgnoreCase("Identifier") && bAuthorList && isOrcid(attributes)) {
                 bOrcid = true;
-            }
-            if (qName.equalsIgnoreCase("AuthorList") &&
-                    pubmedArticle != null) {
-                pubmedArticle.getMedlinecitation().getArticle().setAuthorlist(new ArrayList<>()); // set the PubmedArticle's MedlineCitation's MedlineCitationArticle's title.
-                bAuthorList = true;
             }
             if (qName.equalsIgnoreCase("Abstract") &&
                     pubmedArticle != null) {


### PR DESCRIPTION
## Problem

When PubMed returns a batch containing both `<PubmedArticle>` and `<PubmedBookArticle>` elements, the SAX parser's `pubmedArticle` reference is not cleared between them. Book article fields (AuthorList, Abstract, etc.) overwrite the previously-parsed journal article's data via the still-live reference. The corrupted data is then persisted to DynamoDB.

**Example:** PMID 38461731 (8-author MS study by Zhang et al.) had its author list replaced by 79 authors from PMID 41525446 (a PCORI book report by Limbrick et al. including Jeffrey P. Greenfield).

## Fix

1. **Null out `pubmedArticle` when `<PubmedBookArticle>` is encountered** — this causes all subsequent child element handlers to be skipped since they check `if (pubmedArticle != null)`.

2. **Removed duplicate `AuthorList` handler block** — identical code appeared twice in `startElement`.

## Impact

- Prevents silent data corruption for any `<PubmedArticle>` that precedes a `<PubmedBookArticle>` in an eFetch batch
- Book articles (PCORI reports, Cochrane reviews, GeneReviews, NCBI Bookshelf) are skipped rather than corrupting adjacent records
- Long-term: proper PubmedBookArticle support is planned as a separate effort

## After Merge

Re-retrieve articles for affected users with `refreshFlag=ALL_PUBLICATIONS` to replace corrupted DynamoDB records.