### PR TITLE
Fix SAX parser state leakage for PubmedBookArticle

### DIFF
--- a/src/main/java/reciter/pubmed/xmlparser/PubmedEFetchHandler.java
+++ b/src/main/java/reciter/pubmed/xmlparser/PubmedEFetchHandler.java
@@ -287,6 +287,9 @@ public class PubmedEFetchHandler extends DefaultHandler {
         if (qName.equalsIgnoreCase("PubmedArticle")) {
             pubmedArticle = PubMedArticle.builder().build(); // create a new PubmedArticle.
         }
+        if (qName.equalsIgnoreCase("PubmedBookArticle")) {
+            pubmedArticle = null; // Prevent book article fields from corrupting previous article
+        }
         //This check was introduced for articles which are of book type returning  <PubmedBookArticle> tag
         if (pubmedArticle != null) {
             if (qName.equalsIgnoreCase("MedlineCitation")) {
@@ -424,11 +427,6 @@ public class PubmedEFetchHandler extends DefaultHandler {
             }
             if(qName.equalsIgnoreCase("Identifier") && bAuthorList && isOrcid(attributes)) {
                 bOrcid = true;
-            }
-            if (qName.equalsIgnoreCase("AuthorList") &&
-                    pubmedArticle != null) {
-                pubmedArticle.getMedlinecitation().getArticle().setAuthorlist(new ArrayList<>()); // set the PubmedArticle's MedlineCitation's MedlineCitationArticle's title.
-                bAuthorList = true;
             }
             if (qName.equalsIgnoreCase("Abstract") &&
                     pubmedArticle != null) {


### PR DESCRIPTION
## Summary

Fixes a bug where `PubmedBookArticle` elements in PubMed eFetch responses corrupt the previously-parsed `PubmedArticle` record's data (author list, abstract, etc.) via SAX parser state leakage.

## Changes

- **Null out `pubmedArticle` when `<PubmedBookArticle>` is encountered** — prevents book article fields from overwriting the previous article's data
- **Removed duplicate `AuthorList` handler block** — identical code appeared twice in `startElement`

## Root Cause

`PubmedEFetchHandler.java` uses a single `pubmedArticle` instance variable. When a `<PubmedBookArticle>` follows a `<PubmedArticle>` in the same batch, no new object is created — so the book article's AuthorList, Abstract, etc. overwrite the previous article via the still-live reference.

## Impact

- **Example:** PMID 38461731 (8-author MS study) had its author list silently replaced by 79 authors from PMID 41525446 (a PCORI book report)
- Affects any PubmedArticle that precedes a PubmedBookArticle in an eFetch batch
- Corrupted data persists in DynamoDB until articles are re-retrieved

## Verified on dev

Merged to dev via PR #105 and deployed.

## After merge to master

Re-retrieve articles for affected users with `refreshFlag=ALL_PUBLICATIONS` to replace corrupted DynamoDB records.

## Long-term

Proper PubmedBookArticle parsing is planned as a separate effort (see MULTI_SOURCE_ARCHITECTURE.md in scoring research repo).