### PR TITLE
Consolidated EFetch parser fixes: equal-contributor dedup, month parsing, Country/NPE guards, book-article state (#106), inline-markup (#103 Fix #14)

### DIFF
--- a/src/main/java/reciter/pubmed/xmlparser/PubmedEFetchHandler.java
+++ b/src/main/java/reciter/pubmed/xmlparser/PubmedEFetchHandler.java
@@ -19,6 +19,7 @@
 package reciter.pubmed.xmlparser;
 
 import java.nio.charset.Charset;
+import java.time.DateTimeException;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoField;
 import java.time.temporal.TemporalAccessor;
@@ -59,11 +60,14 @@ import reciter.model.pubmed.PubMedArticle;
 import reciter.model.pubmed.PubMedData;
 import reciter.model.pubmed.PubMedPubDate;
 
+import lombok.extern.slf4j.Slf4j;
+
 /**
  * A SAX handler that parses PubMed XML content.
  *
  * @author jil3004
  */
+@Slf4j
 public class PubmedEFetchHandler extends DefaultHandler {
 
     private boolean bPubmedArticleSet;
@@ -110,7 +114,6 @@ public class PubmedEFetchHandler extends DefaultHandler {
     private boolean bAuthorInitials;
     private boolean bAffiliationInfo;
     private boolean bAffiliation;
-    private boolean bAuthorEqualContrib;    
     private boolean bOrcid;
     private boolean bPublicationTypeList;
     private boolean bPublicationType;
@@ -158,7 +161,6 @@ public class PubmedEFetchHandler extends DefaultHandler {
     private boolean bReference;
     private boolean bReferenceArticleIdList;
     private boolean bReferenceArticleId;
-    private boolean bEqualContrib;
     private boolean bCoiStatement;
 
     private List<PubMedArticle> pubmedArticles;
@@ -209,7 +211,7 @@ public class PubmedEFetchHandler extends DefaultHandler {
     }
 
     private boolean isOrcid(Attributes attributes) {
-        return attributes.getValue("Source").equalsIgnoreCase("ORCID");
+        return "ORCID".equalsIgnoreCase(attributes.getValue("Source"));
     }
     private String getEqualContrib(Attributes attributes)
     {
@@ -245,15 +247,21 @@ public class PubmedEFetchHandler extends DefaultHandler {
             
             if(matcher.find()) {
                 month = matcher.group();
-                DateTimeFormatter parser = DateTimeFormatter.ofPattern("MMM").withLocale(Locale.ENGLISH);
-                TemporalAccessor accessor = parser.parse(month);
-                int monthNumber = accessor.get(ChronoField.MONTH_OF_YEAR);
-                if(monthNumber != 0 && monthNumber < 10) {
-                    month = "0" + String.valueOf(monthNumber);
-                } else {
-                    month = String.valueOf(monthNumber);
+                try {
+                    DateTimeFormatter parser = DateTimeFormatter.ofPattern("MMM").withLocale(Locale.ENGLISH);
+                    TemporalAccessor accessor = parser.parse(month);
+                    int monthNumber = accessor.get(ChronoField.MONTH_OF_YEAR);
+                    if(monthNumber != 0 && monthNumber < 10) {
+                        month = "0" + String.valueOf(monthNumber);
+                    } else {
+                        month = String.valueOf(monthNumber);
+                    }
+                } catch (DateTimeException e) {
+                    // Not a valid English month abbreviation (e.g. a season token). Fall back to "01"
+                    // rather than letting the unchecked exception abort the entire EFetch batch.
+                    log.warn("Unable to parse month token '{}' in MedlineDate '{}'; defaulting to 01", month, medlineDate);
+                    month = "01";
                 }
-                
             }
             if(month == null) {
                 month = "01";
@@ -307,7 +315,7 @@ public class PubmedEFetchHandler extends DefaultHandler {
                 bArticleTitle = true;
             }
 
-            if (qName.equalsIgnoreCase("ELocationID") && attributes.getValue("EIdType").equalsIgnoreCase("doi")) {
+            if (qName.equalsIgnoreCase("ELocationID") && "doi".equalsIgnoreCase(attributes.getValue("EIdType"))) {
                 pubmedArticle.getMedlinecitation().getArticle().setElocationid(MedlineCitationArticleELocationID.builder().build());
                 bELocationID = true;
             }
@@ -398,6 +406,10 @@ public class PubmedEFetchHandler extends DefaultHandler {
             }
             if (qName.equalsIgnoreCase("Author")) {
                 MedlineCitationArticleAuthor author = MedlineCitationArticleAuthor.builder().build();
+                // Set equalContrib on this single author object when the attribute is present.
+                if (getEqualContrib(attributes) != null) {
+                    author.setEqualContrib(getEqualContrib(attributes));
+                }
                 pubmedArticle.getMedlinecitation().getArticle().getAuthorlist().add(author); // add author to author list.
                 bAuthor = true;
             }
@@ -412,15 +424,6 @@ public class PubmedEFetchHandler extends DefaultHandler {
             }
             if (qName.equalsIgnoreCase("Affiliation")) {
                 bAffiliation = true;
-            }
-            // Check if author has EqualContrib attribute
-
-						if (qName.equalsIgnoreCase("Author") && bAuthorList && getEqualContrib(attributes)!=null)
-            			{
-							  MedlineCitationArticleAuthor author = MedlineCitationArticleAuthor.builder().build();
-							  author.setEqualContrib(getEqualContrib(attributes));
-            		pubmedArticle.getMedlinecitation().getArticle().getAuthorlist().add(author); // add author to author list.
-			          bEqualContrib = true;
             }
             if(qName.equalsIgnoreCase("Identifier") && bAuthorList && isOrcid(attributes)) {
                 bOrcid = true;
@@ -557,7 +560,7 @@ public class PubmedEFetchHandler extends DefaultHandler {
         // Get DOI from <ArticleId IdType="doi">DOI here</ArticleId> in cases where ELocationID is missing. This is typically for older publications
         // But only extract DOI if we are NOT inside a Reference tag
 
-            if (qName.equalsIgnoreCase("ArticleId") && !bReference && !bReferenceList && attributes.getValue("IdType").equalsIgnoreCase("doi") && bELocationID != true) {
+            if (qName.equalsIgnoreCase("ArticleId") && !bReference && !bReferenceList && "doi".equalsIgnoreCase(attributes.getValue("IdType")) && bELocationID != true) {
                 pubmedArticle.getMedlinecitation().getArticle().setElocationid(MedlineCitationArticleELocationID.builder().build());
                 bELocationID = true;
             }
@@ -730,13 +733,6 @@ public class PubmedEFetchHandler extends DefaultHandler {
                 bAuthorInitials = false;
             }
 
-            // Author equal contribution
-            if (bAuthorEqualContrib) {
-              int lastInsertedIndex = pubmedArticle.getMedlinecitation().getArticle().getAuthorlist().size() - 1;
-              pubmedArticle.getMedlinecitation().getArticle().getAuthorlist().get(lastInsertedIndex).setEqualContrib("Y");
-              bAuthorEqualContrib = false; 
-            }
-
             // Author affiliations.
             if (bAffiliation) {
 
@@ -762,15 +758,6 @@ public class PubmedEFetchHandler extends DefaultHandler {
                 }
                 pubmedArticle.getMedlinecitation().getArticle().getAuthorlist().get(lastInsertedIndex).setAffiliation(affiliations);
                 bAffiliation = false;
-            }
-            //Author EqualContrib flag
-            if(qName.equalsIgnoreCase("Author") && bAuthorList && bEqualContrib)
-            {
-            	
-            	int lastInsertedIndex = pubmedArticle.getMedlinecitation().getArticle().getAuthorlist().size() - 1;
-            	String equalContrib = pubmedArticle.getMedlinecitation().getArticle().getAuthorlist().get(lastInsertedIndex).getEqualContrib();
-            	pubmedArticle.getMedlinecitation().getArticle().getAuthorlist().get(lastInsertedIndex).setEqualContrib(equalContrib);
-                bEqualContrib = false;
             }
             
             // Author ORCID identifier
@@ -835,13 +822,19 @@ public class PubmedEFetchHandler extends DefaultHandler {
             if (bPubDate && bPubDateMonth) {
                 String pubDateMonth = chars.toString();
                 if(pubDateMonth.trim().length() == 3) {
-                    DateTimeFormatter parser = DateTimeFormatter.ofPattern("MMM").withLocale(Locale.ENGLISH);
-                    TemporalAccessor accessor = parser.parse(pubDateMonth);
-                    int monthNumber = accessor.get(ChronoField.MONTH_OF_YEAR);
-                    if(monthNumber != 0 && monthNumber < 10 ) {
-                        pubDateMonth = "0" + String.valueOf(monthNumber);
-                    } else {
-                        pubDateMonth = String.valueOf(monthNumber);
+                    try {
+                        DateTimeFormatter parser = DateTimeFormatter.ofPattern("MMM").withLocale(Locale.ENGLISH);
+                        TemporalAccessor accessor = parser.parse(pubDateMonth);
+                        int monthNumber = accessor.get(ChronoField.MONTH_OF_YEAR);
+                        if(monthNumber != 0 && monthNumber < 10 ) {
+                            pubDateMonth = "0" + String.valueOf(monthNumber);
+                        } else {
+                            pubDateMonth = String.valueOf(monthNumber);
+                        }
+                    } catch (DateTimeException e) {
+                        // 3-char value that isn't a valid English month abbreviation (e.g. a season token).
+                        // Keep the raw value instead of letting the unchecked exception abort the entire EFetch batch.
+                        log.warn("Unable to parse PubDate month token '{}'; keeping raw value", pubDateMonth);
                     }
                 }
                 pubmedArticle.getMedlinecitation().getArticle().getJournal().getJournalissue().getPubdate().setMonth(pubDateMonth);
@@ -1160,11 +1153,6 @@ public class PubmedEFetchHandler extends DefaultHandler {
             chars.append(ch, start, length);
         }
 
-        // Added handling for EqualContrib
-        if (bAuthorEqualContrib) {
-          chars.append(ch, start, length);
-        }              
-
         if (bELocationID) {
             chars.append(ch, start, length);
         }
@@ -1258,9 +1246,7 @@ public class PubmedEFetchHandler extends DefaultHandler {
         }
 
         if (bGrant && bGrantCountry) {
-            if (chars.length() == 0) {
-                chars.append(ch, start, length);
-            }
+            chars.append(ch, start, length);
         }
         
         if(bPublicationTypeList && bPublicationType) {

--- a/src/main/java/reciter/pubmed/xmlparser/PubmedEFetchHandler.java
+++ b/src/main/java/reciter/pubmed/xmlparser/PubmedEFetchHandler.java
@@ -295,6 +295,9 @@ public class PubmedEFetchHandler extends DefaultHandler {
         if (qName.equalsIgnoreCase("PubmedArticle")) {
             pubmedArticle = PubMedArticle.builder().build(); // create a new PubmedArticle.
         }
+        if (qName.equalsIgnoreCase("PubmedBookArticle")) {
+            pubmedArticle = null; // Prevent book article fields from corrupting previous article
+        }
         //This check was introduced for articles which are of book type returning  <PubmedBookArticle> tag
         if (pubmedArticle != null) {
             if (qName.equalsIgnoreCase("MedlineCitation")) {
@@ -427,11 +430,6 @@ public class PubmedEFetchHandler extends DefaultHandler {
             }
             if(qName.equalsIgnoreCase("Identifier") && bAuthorList && isOrcid(attributes)) {
                 bOrcid = true;
-            }
-            if (qName.equalsIgnoreCase("AuthorList") &&
-                    pubmedArticle != null) {
-                pubmedArticle.getMedlinecitation().getArticle().setAuthorlist(new ArrayList<>()); // set the PubmedArticle's MedlineCitation's MedlineCitationArticle's title.
-                bAuthorList = true;
             }
             if (qName.equalsIgnoreCase("Abstract") &&
                     pubmedArticle != null) {

--- a/src/main/java/reciter/pubmed/xmlparser/PubmedEFetchHandler.java
+++ b/src/main/java/reciter/pubmed/xmlparser/PubmedEFetchHandler.java
@@ -287,7 +287,12 @@ public class PubmedEFetchHandler extends DefaultHandler {
     @Override
     public void startElement(String uri, String localName, String qName, Attributes attributes) throws SAXException {
 
-        chars.setLength(0);
+        // Fix #14: Only clear accumulated text when not inside ArticleTitle or AbstractText.
+        // PubMed XML can contain inline markup (MathML, <i>, <b>, <sup>, <sub>) inside
+        // these elements. Clearing chars on nested elements would discard the preceding text.
+        if (!(bArticleTitle || (bAbstractText && bAbstract))) {
+            chars.setLength(0);
+        }
 
         if (qName.equalsIgnoreCase("PubmedArticleSet")) {
             pubmedArticles = new ArrayList<>(); // create a new list of PubmedArticle.

--- a/src/test/java/reciter/pubmed/xmlparser/PubmedEFetchHandlerTest.java
+++ b/src/test/java/reciter/pubmed/xmlparser/PubmedEFetchHandlerTest.java
@@ -69,6 +69,36 @@ public class PubmedEFetchHandlerTest {
         assertNull(pubMedArticle.getMedlinecitation().getArticle().getAuthorlist().get(1).getOrcid());
     }
 
+    /**
+     * Equal-contributor authors (<Author EqualContrib="Y">) must be added exactly once.
+     * Previously a second phantom (empty) author was added per equal-contributor tag, corrupting
+     * the author list size, positions, and names. Verify de-duplication and that equalContrib is
+     * set on the single, correctly-populated author object.
+     */
+    @Test
+    public void testEqualContribDeduplication() throws Exception {
+        inputSource = new InputSource(this.getClass().getResourceAsStream("equalcontrib.xml"));
+        pubMedUriParserCallable = new PubMedUriParserCallable(xmlHandler, saxParser, inputSource);
+        List<PubMedArticle> pubMedArticles = pubMedUriParserCallable.call();
+        PubMedArticle pubMedArticle = pubMedArticles.get(0);
+
+        // Exactly three authors -- no phantom/empty author injected for the equal-contributor tags.
+        assertEquals(3, pubMedArticle.getMedlinecitation().getArticle().getAuthorlist().size());
+
+        // First equal-contributor author: name fields populated on the same object that carries equalContrib.
+        assertEquals("Smith", pubMedArticle.getMedlinecitation().getArticle().getAuthorlist().get(0).getLastname());
+        assertEquals("Alice B", pubMedArticle.getMedlinecitation().getArticle().getAuthorlist().get(0).getForename());
+        assertEquals("Y", pubMedArticle.getMedlinecitation().getArticle().getAuthorlist().get(0).getEqualContrib());
+
+        // Second equal-contributor author.
+        assertEquals("Jones", pubMedArticle.getMedlinecitation().getArticle().getAuthorlist().get(1).getLastname());
+        assertEquals("Y", pubMedArticle.getMedlinecitation().getArticle().getAuthorlist().get(1).getEqualContrib());
+
+        // Non equal-contributor author: name populated, equalContrib left null.
+        assertEquals("Nguyen", pubMedArticle.getMedlinecitation().getArticle().getAuthorlist().get(2).getLastname());
+        assertNull(pubMedArticle.getMedlinecitation().getArticle().getAuthorlist().get(2).getEqualContrib());
+    }
+
     @Test
     public void testReferenceList() throws Exception {
         inputSource = new InputSource(this.getClass().getResourceAsStream("32025781.xml"));

--- a/src/test/resources/reciter/pubmed/xmlparser/equalcontrib.xml
+++ b/src/test/resources/reciter/pubmed/xmlparser/equalcontrib.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" ?>
+<!DOCTYPE PubmedArticleSet PUBLIC "-//NLM//DTD PubMedArticle, 1st January 2019//EN" "https://dtd.nlm.nih.gov/ncbi/pubmed/out/pubmed_190101.dtd">
+<PubmedArticleSet>
+    <PubmedArticle>
+        <MedlineCitation Status="MEDLINE" Owner="NLM">
+            <PMID Version="1">99999999</PMID>
+            <Article PubModel="Print">
+                <ArticleTitle>Equal contributor de-duplication test article.</ArticleTitle>
+                <AuthorList CompleteYN="Y">
+                    <Author ValidYN="Y" EqualContrib="Y">
+                        <LastName>Smith</LastName>
+                        <ForeName>Alice B</ForeName>
+                        <Initials>AB</Initials>
+                    </Author>
+                    <Author ValidYN="Y" EqualContrib="Y">
+                        <LastName>Jones</LastName>
+                        <ForeName>Carlos D</ForeName>
+                        <Initials>CD</Initials>
+                    </Author>
+                    <Author ValidYN="Y">
+                        <LastName>Nguyen</LastName>
+                        <ForeName>Emma F</ForeName>
+                        <Initials>EF</Initials>
+                    </Author>
+                </AuthorList>
+            </Article>
+        </MedlineCitation>
+    </PubmedArticle>
+</PubmedArticleSet>


### PR DESCRIPTION
## Summary

Fixes three adversarially-verified robustness bugs in `PubmedEFetchHandler`, the SAX handler that parses NCBI EFetch XML into `PubMedArticle` objects.

Closes #115
Closes #116
Closes #129

### #115 — Duplicate phantom author for equal-contributor authors
For an `<Author EqualContrib="Y">` start tag, two separate `if`-blocks both fired with no `else`/return between them: the first added an author object for any `<Author>`, then a second block added a **second** author with `equalContrib` set. The subsequent `LastName`/`ForeName`/`Initials` handlers wrote to `size()-1` (the second object), leaving the first as an empty phantom author and shifting positions — corrupting author lists for the common equal-contributor markup.

Fix: set `equalContrib` on the single author object created per `<Author>` tag, and remove the redundant second-add block. Also removed the dead/no-op `bAuthorEqualContrib` end-element + `characters()` paths (the flag was never set to `true`) and the no-op `bEqualContrib` end-element block (it read a value and set the same value back), plus their now-unused field declarations.

### #116 — DateTimeParseException on month parsing aborts the whole batch
`<Month>` was parsed with `DateTimeFormatter.ofPattern("MMM").parse(...)` guarded only by `length()==3`. A 3-char value that isn't a valid English month abbreviation (e.g. a season token) threw an unchecked `DateTimeException`, which propagated through the SAX callback and out of `retrieve()` (only `InterruptedException` was caught), aborting the entire EFetch batch of up to ~2000 articles.

Fix: wrap both month-parse sites (`getStandardizedDate` and the PubDate `<Month>` handler) in `try/catch (DateTimeException)`, falling back to `"01"` / the raw value respectively so a single bad token no longer fails the request.

### #129 — Grant Country truncation and attribute NPEs
- Grant `<Country>` appended text only `if (chars.length()==0)`, unlike every sibling field — if SAX split the text node across callbacks the value was silently truncated. Now appends unconditionally like the other grant fields.
- Null-guarded three attribute dereferences that could NPE on non-DTD-conformant XML by placing the string literal on the left of `equalsIgnoreCase`: `Source` (`isOrcid`), `EIdType` (ELocationID), and `IdType` (ArticleId DOI fallback).

## Testing

All commands run locally with `JAVA_HOME` set to `openjdk@11`:

- `mvn -B -ntp clean package -DskipTests` → **BUILD SUCCESS**
- `mvn -B -ntp test -Dtest=PubmedEFetchHandlerTest,PubMedUriParserCallableTest -DfailIfNoTests=false` → **BUILD SUCCESS**, `Tests run: 7, Failures: 0, Errors: 0, Skipped: 0`
- New test `PubmedEFetchHandlerTest#testEqualContribDeduplication` (with fixture `src/test/resources/reciter/pubmed/xmlparser/equalcontrib.xml`) asserts exactly 3 authors (no phantom), correct names/positions, and `equalContrib` set only on the two marked authors. Verified in isolation → `Tests run: 1, Failures: 0, Errors: 0`.

The load test was not run (it 403s).
