### PR TITLE
Harden NCBI HTTP handling: timeouts, shared client, retry/header guards, query-drop on retrieval path, redact API key, XXE

### DIFF
--- a/src/main/java/reciter/config/HttpClientConfig.java
+++ b/src/main/java/reciter/config/HttpClientConfig.java
@@ -1,0 +1,53 @@
+package reciter.config;
+
+import org.apache.http.client.config.CookieSpecs;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Provides a single shared, pooled, timeout-bounded {@link CloseableHttpClient} for all
+ * outbound calls to the NCBI E-utilities API.
+ *
+ * <p>Using one pooled client (instead of {@code HttpClients.createDefault()} per request)
+ * allows TCP/TLS connection reuse and prevents connection/file-descriptor leaks under load.
+ * The {@link RequestConfig} timeouts ensure a slow or stalled NCBI response can never wedge
+ * a servlet worker thread indefinitely.
+ */
+@Configuration
+public class HttpClientConfig {
+
+    /** Time to establish a TCP connection to NCBI. */
+    private static final int CONNECT_TIMEOUT_MILLIS = 5_000;
+
+    /** Time to wait between data packets once connected (read timeout). */
+    private static final int SOCKET_TIMEOUT_MILLIS = 60_000;
+
+    /** Time to wait for a connection from the pool. */
+    private static final int CONNECTION_REQUEST_TIMEOUT_MILLIS = 5_000;
+
+    private static final int MAX_TOTAL_CONNECTIONS = 50;
+    private static final int MAX_CONNECTIONS_PER_ROUTE = 50;
+
+    @Bean(destroyMethod = "close")
+    public CloseableHttpClient pubMedHttpClient() {
+        PoolingHttpClientConnectionManager connectionManager = new PoolingHttpClientConnectionManager();
+        connectionManager.setMaxTotal(MAX_TOTAL_CONNECTIONS);
+        connectionManager.setDefaultMaxPerRoute(MAX_CONNECTIONS_PER_ROUTE);
+
+        RequestConfig requestConfig = RequestConfig.custom()
+                .setConnectTimeout(CONNECT_TIMEOUT_MILLIS)
+                .setSocketTimeout(SOCKET_TIMEOUT_MILLIS)
+                .setConnectionRequestTimeout(CONNECTION_REQUEST_TIMEOUT_MILLIS)
+                .setCookieSpec(CookieSpecs.STANDARD)
+                .build();
+
+        return HttpClients.custom()
+                .setConnectionManager(connectionManager)
+                .setDefaultRequestConfig(requestConfig)
+                .build();
+    }
+}

--- a/src/main/java/reciter/controller/PubMedRetrievalToolController.java
+++ b/src/main/java/reciter/controller/PubMedRetrievalToolController.java
@@ -1,35 +1,17 @@
 package reciter.controller;
 
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.StringWriter;
 import java.net.URLEncoder;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.bohnman.squiggly.Squiggly;
 import com.github.bohnman.squiggly.util.SquigglyUtils;
 
-import org.apache.commons.io.IOUtils;
-import org.apache.http.Header;
-import org.apache.http.HttpEntity;
-import org.apache.http.HttpResponse;
-import org.apache.http.NameValuePair;
-import org.apache.http.client.HttpClient;
-import org.apache.http.client.entity.UrlEncodedFormEntity;
-import org.apache.http.client.methods.HttpPost;
-import org.apache.http.client.params.ClientPNames;
-import org.apache.http.impl.client.HttpClients;
-import org.apache.http.message.BasicNameValuePair;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
@@ -47,8 +29,6 @@ import io.swagger.annotations.ApiResponses;
 import lombok.extern.slf4j.Slf4j;
 import reciter.model.pubmed.PubMedArticle;
 import reciter.pubmed.model.PubMedQuery;
-import reciter.pubmed.model.PubmedESearchResult;
-import reciter.pubmed.querybuilder.PubmedXmlQuery;
 import reciter.pubmed.retriever.PubMedArticleRetrievalService;
 
 @Slf4j
@@ -59,8 +39,6 @@ public class PubMedRetrievalToolController {
 
     @Autowired
     private PubMedArticleRetrievalService pubMedArticleRetrievalService;
-    
-    private static ObjectMapper objectMapper = new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 
     @ApiOperation(value = "Query with field selection.", response = List.class)
     @ApiResponses(value = {
@@ -93,140 +71,12 @@ public class PubMedRetrievalToolController {
     @RequestMapping(value = "/query-number-pubmed-articles/", method = RequestMethod.POST)
     @ResponseBody
     public int getNumberOfPubMedArticles(@RequestBody PubMedQuery pubMedQuery) throws IOException {
-    	
-        PubmedXmlQuery pubmedXmlQuery = new PubmedXmlQuery(URLEncoder.encode(pubMedQuery.toString(), "UTF-8"));
-        //pubmedXmlQuery.setRetMax(1);
-        pubmedXmlQuery.setRetStart(0);
-        String fullUrl = pubmedXmlQuery.buildESearchQuery(); // build eSearch query.
-        log.info("ESearch Query=[" + fullUrl + "]");
-        //PubmedESearchHandler pubmedESearchHandler = new PubmedESearchHandler();
-        PubmedESearchResult eSearchResult = new PubmedESearchResult();
-        HttpClient httpClient = HttpClients.createDefault();
-        if(pubmedXmlQuery.getApiKey() != null &&
-       		  !pubmedXmlQuery.getApiKey().isEmpty()) {
-        	fullUrl = PubmedXmlQuery.ESEARCH_BASE_URL + "?api_key=" + pubmedXmlQuery.getApiKey();
-        } else {
-        	fullUrl = PubmedXmlQuery.ESEARCH_BASE_URL;
-        }
-        
-        HttpPost httppost = new HttpPost(fullUrl);
-        // Request parameters and other properties.
-        List<NameValuePair> params = new ArrayList<>();
-        params.add(new BasicNameValuePair("db", pubmedXmlQuery.getDb()));
-        params.add(new BasicNameValuePair("retmax", String.valueOf(pubmedXmlQuery.getRetMax())));
-        params.add(new BasicNameValuePair("usehistory", pubmedXmlQuery.getUseHistory()));
-        params.add(new BasicNameValuePair("term", java.net.URLDecoder.decode(pubmedXmlQuery.getTerm(), "UTF-8")));
-        params.add(new BasicNameValuePair("retmode", pubmedXmlQuery.getRetMode()));
-        params.add(new BasicNameValuePair("retstart", String.valueOf(pubmedXmlQuery.getRetStart())));
-        httppost.setEntity(new UrlEncodedFormEntity(params));
-        httppost.setHeader("Content-Type", "application/x-www-form-urlencoded");
-        httppost.getParams().setParameter(ClientPNames.COOKIE_POLICY, "standard");
-        httppost.setHeader("cache-control", "no-cache");
-
-        //Execute and get the response.
-        
-        HttpResponse response = httpClient.execute(httppost);
-        
-        Header[] headerRateLimitRemaining = response.getHeaders("X-RateLimit-Remaining");
-        Header[] headerRateLimit = response.getHeaders("X-RateLimit-Limit");
-        Header[] headerRetryAfter = response.getHeaders("Retry-After");
-        
-        if(pubMedQuery!=null && headerRateLimit!=null && headerRateLimit.length > 0 && headerRateLimit[0]!=null 
-        		&& headerRateLimitRemaining!=null && headerRateLimitRemaining.length >0 && headerRateLimitRemaining[0]!=null)
-        log.info("Query : " + pubMedQuery.toString()  + " " + headerRateLimit[0].toString() + " " + headerRateLimitRemaining[0].toString());
-        
-        if(headerRateLimitRemaining != null && headerRateLimitRemaining.length > 0 && headerRateLimitRemaining[0] != null && Integer.parseInt(headerRateLimitRemaining[0].getValue()) == 0) {
-        	if(headerRetryAfter != null && headerRetryAfter.length > 0 && headerRetryAfter[0] != null) {
-        		log.info("Query : " + pubMedQuery.toString()  + " " + headerRetryAfter[0].toString());
-        		try {
-        			Thread.sleep(Long.parseLong(headerRetryAfter[0].getValue()) * 1000L);
-        		} catch (InterruptedException e) {
-        			log.error("InterruptedException", e);
-        		}
-        		response = httpClient.execute(httppost);
-        	}
-        }
-		/*
-		 * for (Header header : headers) {
-		 * if(header.getName().equalsIgnoreCase("X-RateLimit-Limit") ||
-		 * header.getName().equalsIgnoreCase("X-RateLimit-Remaining") ||
-		 * header.getName().equalsIgnoreCase("Retry-After")) { log.info("Key : " +
-		 * header.getName() + " ,Value : " + header.getValue()); } }
-		 */
-        HttpEntity entity = response.getEntity();
-        if (entity != null) {
-            InputStream esearchStream = entity.getContent();
-			
-			  StringWriter writer = new StringWriter(); 
-			  IOUtils.copy(esearchStream, writer,"UTF-8"); 
-			  log.info(writer.toString());
-			  String responseString = writer.toString();
-            //SAXParserFactory.newInstance().newSAXParser().parse(esearchStream, pubmedESearchHandler);
-			if (responseString!=null && !responseString.equalsIgnoreCase("") && responseString.trim().startsWith("{") && objectMapper.readTree(responseString).has("esearchresult")) 
-			{  
-		            JsonNode json = objectMapper.readTree(responseString).get("esearchresult");
-		            log.info("PubMed Response Json:",json);
-		
-		            // Extract the "querytranslation" field
-			         String queryTranslation = json.path("querytranslation").asText();
-			         log.info("query translation prior to processing:",queryTranslation);
-			         // Check if the string contains [Affiliation], if it does, stop processing
-			         if (isValidAuthorString(queryTranslation)) {
-			        	 log.info("Entered into process firstNameInitial stragey query");
-			        	 
-			             // Split the string by [Author] and process each part
-			             List<String> segments = //Arrays.stream(queryTranslation.split("(?<=\\[Author\\])")) // Split the string by [Author]
-				            		 			 Arrays.stream(queryTranslation.split("\\[Author\\]")) // Split by [Author]
-				                                       .map(String::trim)  // Trim spaces around each part
-			                                           .map(part -> part.replaceAll("\\b(AND|OR)\\b", ""))  // Remove "AND" and "OR"
-			                                           .map(part -> part.replaceAll("\\s", ""))  // Remove all spaces
-			                                           .filter(part -> !part.isEmpty())  // Filter out empty parts
-			                                           .collect(Collectors.toList());
-			         
-			             // Flag to check if we found a valid segment (length > 2)
-			             boolean isValidSegmentFound = false;
-		
-			             // Iterate over each segment
-			             for (String part : segments) {
-			                 if (part.length() > 2) {
-			                     isValidSegmentFound = true; // We found a valid segment
-			                     break;  // Once we find a valid part, we stop further checks and proceed
-			                 }
-			             }
-			             
-			             
-			             // After the loop, if no valid segment was found, throw an exception
-			             if (!isValidSegmentFound) {
-			            	 log.error("No First Name initial found with more than 2 letters.Hence ignoring the " + eSearchResult.getCount() + "records returned from the PubMed");
-			            	 eSearchResult.setCount(0);
-			                 
-			             }
-			             else
-			             {
-			            	 if(json != null) {
-				     				eSearchResult = objectMapper.treeToValue(json, PubmedESearchResult.class);
-				     				log.info("eSearchResult count for the firstNameInitial strategy :",eSearchResult.getCount());
-				     			} 
-			             }
-			         }
-			         else
-			         {	 
-						if(json !=  null) {
-							eSearchResult = objectMapper.treeToValue(json, PubmedESearchResult.class);
-						}
-			         }
-		        
-		        log.info("esearchResults Count :"+eSearchResult.getCount());
-		        return eSearchResult.getCount();
-          }
-		  else
-		  {
-			  log.error("Unexpected response (not JSON), possibly an HTML error page.");
-			  return 0;
-		  }
-				
-        }
-        return 0;
+        // Delegate to the shared ESearch helper so query-drop detection, rate-limit handling,
+        // and HTTP/timeout behavior are identical to the article-retrieval path.
+        String encodedTerm = URLEncoder.encode(pubMedQuery.toString(), "UTF-8");
+        int count = pubMedArticleRetrievalService.getNumberOfPubMedArticles(encodedTerm).getCount();
+        log.info("esearchResults Count :" + count);
+        return count;
     }
 
     private List<PubMedArticle> retrieve(String query, String fields) throws IOException {
@@ -255,25 +105,5 @@ public class PubMedRetrievalToolController {
         });
         log.info("retrieved " + pubMedArticles.size() + " PubMed articles using query=[" + query + "]");
         return result;
-    }
-    private static boolean isValidAuthorString(String input) {
-        // Regular expression to match anything inside square brackets
-        Pattern pattern = Pattern.compile("\\[(.*?)\\]");
-        
-        Matcher matcher = pattern.matcher(input);
-        boolean containsAuthor = false;
-
-        while (matcher.find()) {
-            String matchedContent = matcher.group(1).trim(); // Get the content inside []
-
-            // Check if the content is neither empty nor anything other than "Author"
-            if (!"Author".equals(matchedContent) && !"All Fields".equals(matchedContent)) {
-                return false; // Found something invalid inside []
-            }
-            containsAuthor = true; // We found [Author]
-        }
-
-        // Return true if at least one [Author] exists, and no other value inside []
-        return containsAuthor;
     }
 }

--- a/src/main/java/reciter/pubmed/callable/PubMedUriParserCallable.java
+++ b/src/main/java/reciter/pubmed/callable/PubMedUriParserCallable.java
@@ -12,11 +12,21 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringReader;
 import java.net.URL;
+import java.net.URLConnection;
 import java.util.List;
 import java.util.concurrent.Callable;
 
 @AllArgsConstructor
 public class PubMedUriParserCallable implements Callable<List<PubMedArticle>> {
+
+    /** Time to establish a TCP connection to NCBI for the EFetch fetch. */
+    private static final int CONNECT_TIMEOUT_MILLIS = 5_000;
+
+    /** Read timeout once connected, so a stalled EFetch response can never wedge a worker thread. */
+    private static final int READ_TIMEOUT_MILLIS = 60_000;
+
+    /** Only the NCBI E-utilities host may be fetched (SSRF guard on the SAX system-id). */
+    private static final String EXPECTED_HOST = "www.ncbi.nlm.nih.gov";
 
     private final PubmedEFetchHandler xmlHandler;
     private final SAXParser saxParser;
@@ -34,13 +44,21 @@ public class PubMedUriParserCallable implements Callable<List<PubMedArticle>> {
     }
 
     private InputSource preprocessSpecialCharacters(InputSource inputSource) throws IOException {
-        InputStream inputStream;
+        String xml;
         if (inputSource.getSystemId() != null) {
-            inputStream = new URL(inputSource.getSystemId()).openStream();
+            URL url = new URL(inputSource.getSystemId());
+            if (!EXPECTED_HOST.equalsIgnoreCase(url.getHost())) {
+                throw new IOException("Refusing to fetch EFetch XML from unexpected host: " + url.getHost());
+            }
+            URLConnection connection = url.openConnection();
+            connection.setConnectTimeout(CONNECT_TIMEOUT_MILLIS);
+            connection.setReadTimeout(READ_TIMEOUT_MILLIS);
+            try (InputStream inputStream = connection.getInputStream()) {
+                xml = IOUtils.toString(inputStream);
+            }
         } else {
-            inputStream = inputSource.getByteStream();
+            xml = IOUtils.toString(inputSource.getByteStream());
         }
-        String xml = IOUtils.toString(inputStream);
         xml = xml.replace("<sup>", "&lt;sup&gt;");
         xml = xml.replace("</sup>", "&lt;/sup&gt;");
         xml = xml.replace("<sub>", "&lt;sub&gt;");

--- a/src/main/java/reciter/pubmed/querybuilder/PubmedXmlQuery.java
+++ b/src/main/java/reciter/pubmed/querybuilder/PubmedXmlQuery.java
@@ -148,7 +148,22 @@ public class PubmedXmlQuery {
         sb.append("xml");               
         sb.append("&WebEnv=");
         sb.append(webEnv);
-        
+
         return sb.toString();
+    }
+
+    /**
+     * Redacts the {@code api_key} value from a query URL so that the NCBI API key is never
+     * written to logs. The key value is replaced with {@code REDACTED} while preserving the
+     * rest of the URL for debugging.
+     *
+     * @param url a query URL that may contain an {@code api_key} parameter
+     * @return the URL with the api_key value redacted, or {@code null} if the input was null
+     */
+    public static String redactApiKey(String url) {
+        if (url == null) {
+            return null;
+        }
+        return url.replaceAll("(?i)(api_key=)[^&]*", "$1REDACTED");
     }
 }

--- a/src/main/java/reciter/pubmed/retriever/PubMedArticleRetrievalService.java
+++ b/src/main/java/reciter/pubmed/retriever/PubMedArticleRetrievalService.java
@@ -4,15 +4,11 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringWriter;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 import javax.xml.XMLConstants;
 import javax.xml.parsers.ParserConfigurationException;
@@ -263,31 +259,10 @@ public class PubMedArticleRetrievalService {
             return eSearchResult;
         }
 
-        // Extract the "querytranslation" field and apply query-drop detection.
-        String queryTranslation = json.path("querytranslation").asText();
-        if (isValidAuthorString(queryTranslation)) {
-            log.info("Entered into process firstNameInitial strategy query");
-            // Split the string by [Author] and process each part.
-            List<String> segments = Arrays.stream(queryTranslation.split("\\[Author\\]"))
-                    .map(String::trim)
-                    .map(part -> part.replaceAll("\\b(AND|OR)\\b", ""))
-                    .map(part -> part.replaceAll("\\s", ""))
-                    .filter(part -> !part.isEmpty())
-                    .collect(Collectors.toList());
-
-            boolean isValidSegmentFound = false;
-            for (String part : segments) {
-                if (part.length() > 2) {
-                    isValidSegmentFound = true;
-                    break;
-                }
-            }
-
-            if (!isValidSegmentFound) {
-                log.error("No First Name initial found with more than 2 letters. Hence ignoring the records returned from PubMed for query=[{}].", term);
-                eSearchResult.setCount(0);
-                return eSearchResult;
-            }
+        // Query-drop detection (Fix #24): only act when PubMed actually reports dropped
+        // phrases (errorlist.phrasenotfound) leaving a trivial query; then discard the noise.
+        if (isPubMedQueryDropped(json, term)) {
+            return eSearchResult; // count stays 0
         }
 
         eSearchResult = objectMapper.treeToValue(json, PubmedESearchResult.class);
@@ -356,22 +331,34 @@ public class PubMedArticleRetrievalService {
         return false;
     }
 
-    private static boolean isValidAuthorString(String input) {
-        // Regular expression to match anything inside square brackets.
-        Pattern pattern = Pattern.compile("\\[(.*?)\\]");
-        Matcher matcher = pattern.matcher(input);
-        boolean containsAuthor = false;
-
-        while (matcher.find()) {
-            String matchedContent = matcher.group(1).trim(); // Get the content inside [].
-            // Check if the content is neither empty nor anything other than "Author".
-            if (!"Author".equals(matchedContent) && !"All Fields".equals(matchedContent)) {
-                return false; // Found something invalid inside [].
-            }
-            containsAuthor = true; // We found [Author].
+    /**
+     * Query-drop detection (Fix #24). PubMed silently drops unrecognized name parts
+     * (e.g. "Charles-rawlins J[au]" becomes "J[au]"), returning many irrelevant results.
+     * Detect this via PubMed's authoritative {@code errorlist.phrasenotfound} signal: only if it
+     * reports dropped phrases AND the remaining {@code querytranslation} is trivially short
+     * (<= 2 chars after stripping field tags, boolean operators and punctuation) are the results
+     * treated as noise. This avoids false positives on legitimately short author queries.
+     *
+     * @param esearchJson   the "esearchresult" JSON node from PubMed's ESearch response
+     * @param originalQuery the original query term (for logging)
+     * @return true if the query was dropped and the results should be discarded
+     */
+    protected static boolean isPubMedQueryDropped(JsonNode esearchJson, String originalQuery) {
+        JsonNode phraseNotFound = esearchJson.path("errorlist").path("phrasenotfound");
+        if (!phraseNotFound.isArray() || phraseNotFound.size() == 0) {
+            return false; // PubMed did not drop any phrases.
         }
-
-        // Return true if at least one [Author] exists, and no other value inside [].
-        return containsAuthor;
+        String queryTranslation = esearchJson.path("querytranslation").asText("");
+        String stripped = queryTranslation
+                .replaceAll("\\[(?:Author|au|All Fields)\\]", "")
+                .replaceAll("\\b(AND|OR)\\b", "")
+                .replaceAll("[()\"\\s]", "")
+                .trim();
+        if (stripped.length() <= 2) {
+            log.warn("PubMed dropped query terms {} from query [{}]. QueryTranslation='{}' is trivial (stripped='{}'). Returning 0 results.",
+                    phraseNotFound, originalQuery, queryTranslation, stripped);
+            return true;
+        }
+        return false;
     }
 }

--- a/src/main/java/reciter/pubmed/retriever/PubMedArticleRetrievalService.java
+++ b/src/main/java/reciter/pubmed/retriever/PubMedArticleRetrievalService.java
@@ -2,12 +2,19 @@ package reciter.pubmed.retriever;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.StringWriter;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
+import javax.xml.XMLConstants;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.parsers.SAXParser;
 import javax.xml.parsers.SAXParserFactory;
@@ -16,17 +23,18 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import org.apache.commons.io.IOUtils;
 import org.apache.http.Header;
 import org.apache.http.HttpEntity;
-import org.apache.http.HttpResponse;
 import org.apache.http.NameValuePair;
-import org.apache.http.client.HttpClient;
 import org.apache.http.client.entity.UrlEncodedFormEntity;
+import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpPost;
-import org.apache.http.client.params.ClientPNames;
-import org.apache.http.impl.client.HttpClients;
+import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.message.BasicNameValuePair;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Recover;
 import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Service;
 import org.xml.sax.InputSource;
@@ -44,8 +52,11 @@ import reciter.pubmed.xmlparser.PubmedEFetchHandler;
 public class PubMedArticleRetrievalService {
 
     private static final int RETRIEVAL_THRESHOLD = 2000;
-    
+
     private static ObjectMapper objectMapper = new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+
+    @Autowired
+    private CloseableHttpClient pubMedHttpClient;
 
     /*@Autowired
     private SAXParser saxParser;
@@ -54,19 +65,27 @@ public class PubMedArticleRetrievalService {
     public SAXParser saxParser() throws ParserConfigurationException, SAXException {
         return SAXParserFactory.newInstance().newSAXParser();
     }*/
-    
+
     //To avoid thread errors - FWK005 parse may not be called while parsing.
     //https://stackoverflow.com/questions/39658247/singleton-thread-safe-sax-parser-instance
     private final ThreadLocal<SAXParserFactory> factoryThreadLocal = new ThreadLocal<SAXParserFactory>() {
         public SAXParserFactory initialValue() {
             try {
-                return SAXParserFactory.newInstance();
+                SAXParserFactory factory = SAXParserFactory.newInstance();
+                // Harden against XXE: disallow DOCTYPE declarations and disable external
+                // entity/DTD resolution. This is defense-in-depth for an XML-parsing service.
+                factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+                factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+                factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+                factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+                factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+                return factory;
             } catch (Exception e) {
                 throw new RuntimeException(e);
             }
         }
    };
-   
+
    public SAXParser getSaxParser() throws ParserConfigurationException, SAXException {
 	   return factoryThreadLocal.get().newSAXParser();
    }
@@ -75,10 +94,10 @@ public class PubMedArticleRetrievalService {
      * Initializes and starts threads that handles the retrieval process. Partition the number of articles
      * into manageable pieces and ask each thread to handle one partition.
      */
-    @Retryable(maxAttempts = 7, value = RuntimeException.class, 
+    @Retryable(maxAttempts = 7, value = IOException.class,
         backoff = @Backoff(random = true, delay = 1500, maxDelay = 9000), listeners = {"retryListener"})
     public List<PubMedArticle> retrieve(String pubMedQuery) throws IOException {
-    	
+
     	PubmedESearchResult eSearchResult = new PubmedESearchResult();
     	eSearchResult = getNumberOfPubMedArticles(pubMedQuery);
 
@@ -88,7 +107,7 @@ public class PubMedArticleRetrievalService {
         if (numberOfPubmedArticles <= RETRIEVAL_THRESHOLD) {
             ExecutorService executor = Executors.newWorkStealingPool();
         	//ScheduledExecutorService executor = (ScheduledExecutorService) Executors.newScheduledThreadPool(10);
-        	
+
 
             // Get the count (number of publications for this query).
             PubmedXmlQuery pubmedXmlQuery = new PubmedXmlQuery();
@@ -109,8 +128,8 @@ public class PubMedArticleRetrievalService {
 
             //List<RetryerCallable<List<PubMedArticle>>> callables = new ArrayList<RetryerCallable<List<PubMedArticle>>>();
             List<Callable<List<PubMedArticle>>> callables = new ArrayList<>();
-            
-            
+
+
 
             // Use the retstart value to iteratively fetch all XMLs.
             while (numberOfPubmedArticles > 0) {
@@ -125,9 +144,9 @@ public class PubMedArticleRetrievalService {
 
                 // Use the webenv value to retrieve xml.
                 String eFetchUrl = pubmedXmlQuery.buildEFetchQuery();
-                log.info("eFetchUrl=[{}].", eFetchUrl);
-                
-                
+                log.info("eFetchUrl=[{}].", PubmedXmlQuery.redactApiKey(eFetchUrl));
+
+
 
                 try {
                 	//PubMedUriParserCallable callable = new PubMedUriParserCallable(new PubmedEFetchHandler(), getSaxParser(), new InputSource(eFetchUrl));
@@ -143,27 +162,33 @@ public class PubMedArticleRetrievalService {
                 pubmedXmlQuery.setRetStart(currentRetStart);
                 numberOfPubmedArticles -= pubmedXmlQuery.getRetMax();
             }
-            
-			
+
+
 			/*
 			 * for(Callable<List<PubMedArticle>> callable: callables) {
 			 * executor.schedule(callable, 5, TimeUnit.SECONDS); }
 			 */
-			 
+
 
             try {
-                executor.invokeAll(callables)
-                        .stream()
-                        .map(future -> {
-                            try {
-                                return future.get();
-                            } catch (Exception e) {
-                                log.error("Unable to retrieve result using future get.");
-                                throw new IllegalStateException(e);
-                            }
-                        }).forEach(pubMedArticles::addAll);
+                List<java.util.concurrent.Future<List<PubMedArticle>>> futures = executor.invokeAll(callables);
+                for (java.util.concurrent.Future<List<PubMedArticle>> future : futures) {
+                    try {
+                        pubMedArticles.addAll(future.get());
+                    } catch (ExecutionException e) {
+                        log.error("Unable to retrieve result using future get.");
+                        Throwable cause = e.getCause();
+                        if (cause instanceof IOException) {
+                            throw (IOException) cause;
+                        }
+                        throw new IOException("Failed to fetch/parse EFetch result", cause);
+                    }
+                }
             } catch (InterruptedException e) {
                 log.error("Unable to invoke callable.", e);
+                Thread.currentThread().interrupt();
+            } finally {
+                executor.shutdownNow();
             }
         } else {
             throw new IOException("Number of PubMed Articles retrieved " + numberOfPubmedArticles + " exceeded the threshold level " + RETRIEVAL_THRESHOLD);
@@ -171,25 +196,47 @@ public class PubMedArticleRetrievalService {
         return pubMedArticles;
     }
 
-    protected PubmedESearchResult getNumberOfPubMedArticles(String query) throws IOException {
-        PubmedXmlQuery pubmedXmlQuery = new PubmedXmlQuery(query);
-        //pubmedXmlQuery.setRetMax(1);
-        String fullUrl = pubmedXmlQuery.buildESearchQuery(); // build eSearch query.
-        log.info("ESearch Query=[{}]", fullUrl);
-        
-        if(pubmedXmlQuery.getApiKey() != null &&
-         		  !pubmedXmlQuery.getApiKey().isEmpty()) {
-          	fullUrl = PubmedXmlQuery.ESEARCH_BASE_URL + "?api_key=" + pubmedXmlQuery.getApiKey();
-	      } else {
-	      	fullUrl = PubmedXmlQuery.ESEARCH_BASE_URL;
-	      }
+    /**
+     * Recovery handler invoked when {@link #retrieve(String)} exhausts all retry attempts.
+     * Re-throws the final exception rather than silently swallowing it so callers still see
+     * the failure, but provides a single, well-defined termination point for the retry loop.
+     */
+    @Recover
+    public List<PubMedArticle> recoverRetrieve(IOException e, String pubMedQuery) throws IOException {
+        log.error("Exhausted retries retrieving PubMed articles for query=[{}].", pubMedQuery, e);
+        throw e;
+    }
 
-        //PubmedESearchHandler pubmedESearchHandler = new PubmedESearchHandler();
+    public PubmedESearchResult getNumberOfPubMedArticles(String query) throws IOException {
+        return executeESearch(query);
+    }
+
+    /**
+     * Executes a single ESearch request against NCBI via HTTP POST. Handles rate-limit headers
+     * (sleeping and retrying once when the remaining quota is exhausted) and applies the
+     * query-drop detection (Fix #24): when PubMed silently drops a name part leaving a trivial
+     * author query, the returned count is zeroed so dropped-term queries are neutralized on
+     * every code path that performs an ESearch (both the count endpoint and the retrieval path).
+     *
+     * @param term URL-encoded Entrez query term (as stored in {@link PubmedXmlQuery#getTerm()})
+     * @return the parsed {@link PubmedESearchResult}; count is 0 for trivial/dropped queries or
+     *         non-JSON (e.g. HTML error page) responses.
+     */
+    protected PubmedESearchResult executeESearch(String term) throws IOException {
+        PubmedXmlQuery pubmedXmlQuery = new PubmedXmlQuery(term);
+        pubmedXmlQuery.setRetStart(0);
+        log.info("ESearch Query=[{}]", PubmedXmlQuery.redactApiKey(pubmedXmlQuery.buildESearchQuery()));
+
+        String postUrl;
+        if (pubmedXmlQuery.getApiKey() != null && !pubmedXmlQuery.getApiKey().isEmpty()) {
+            postUrl = PubmedXmlQuery.ESEARCH_BASE_URL + "?api_key=" + pubmedXmlQuery.getApiKey();
+        } else {
+            postUrl = PubmedXmlQuery.ESEARCH_BASE_URL;
+        }
+
         PubmedESearchResult eSearchResult = new PubmedESearchResult();
-        //InputStream esearchStream = new URL(fullUrl).openStream();
 
-        HttpClient httpClient = HttpClients.createDefault();
-        HttpPost httppost = new HttpPost(fullUrl);
+        HttpPost httppost = new HttpPost(postUrl);
         // Request parameters and other properties.
         List<NameValuePair> params = new ArrayList<>();
         params.add(new BasicNameValuePair("db", pubmedXmlQuery.getDb()));
@@ -200,52 +247,131 @@ public class PubMedArticleRetrievalService {
         params.add(new BasicNameValuePair("retstart", String.valueOf(pubmedXmlQuery.getRetStart())));
         httppost.setEntity(new UrlEncodedFormEntity(params));
         httppost.setHeader("Content-Type", "application/x-www-form-urlencoded");
-        httppost.getParams().setParameter(ClientPNames.COOKIE_POLICY, "standard");
         httppost.setHeader("cache-control", "no-cache");
-        
-        //Execute and get the response.
-        HttpResponse response = httpClient.execute(httppost);
-        
+
+        String responseString = executeReadingBody(httppost, term);
+
+        if (responseString == null || responseString.trim().isEmpty()
+                || !responseString.trim().startsWith("{")
+                || !objectMapper.readTree(responseString).has("esearchresult")) {
+            log.error("Unexpected response (not JSON), possibly an HTML error page.");
+            return eSearchResult;
+        }
+
+        JsonNode json = objectMapper.readTree(responseString).get("esearchresult");
+        if (json == null) {
+            return eSearchResult;
+        }
+
+        // Extract the "querytranslation" field and apply query-drop detection.
+        String queryTranslation = json.path("querytranslation").asText();
+        if (isValidAuthorString(queryTranslation)) {
+            log.info("Entered into process firstNameInitial strategy query");
+            // Split the string by [Author] and process each part.
+            List<String> segments = Arrays.stream(queryTranslation.split("\\[Author\\]"))
+                    .map(String::trim)
+                    .map(part -> part.replaceAll("\\b(AND|OR)\\b", ""))
+                    .map(part -> part.replaceAll("\\s", ""))
+                    .filter(part -> !part.isEmpty())
+                    .collect(Collectors.toList());
+
+            boolean isValidSegmentFound = false;
+            for (String part : segments) {
+                if (part.length() > 2) {
+                    isValidSegmentFound = true;
+                    break;
+                }
+            }
+
+            if (!isValidSegmentFound) {
+                log.error("No First Name initial found with more than 2 letters. Hence ignoring the records returned from PubMed for query=[{}].", term);
+                eSearchResult.setCount(0);
+                return eSearchResult;
+            }
+        }
+
+        eSearchResult = objectMapper.treeToValue(json, PubmedESearchResult.class);
+        log.info("esearchResults Count :" + eSearchResult.getCount());
+        return eSearchResult;
+    }
+
+    /**
+     * Executes the ESearch POST and returns the response body. When the NCBI rate-limit quota is
+     * exhausted (X-RateLimit-Remaining == 0) and a Retry-After header is present, sleeps for the
+     * advertised interval and replays the request once, returning the replayed response body.
+     * Response entities are always closed via try-with-resources.
+     */
+    private String executeReadingBody(HttpPost httppost, String query) throws IOException {
+        try (CloseableHttpResponse response = pubMedHttpClient.execute(httppost)) {
+            if (shouldRetryAfterRateLimit(response, query)) {
+                try (CloseableHttpResponse retryResponse = pubMedHttpClient.execute(httppost)) {
+                    return readBody(retryResponse);
+                }
+            }
+            return readBody(response);
+        }
+    }
+
+    private static String readBody(CloseableHttpResponse response) throws IOException {
+        HttpEntity entity = response.getEntity();
+        if (entity == null) {
+            return null;
+        }
+        StringWriter writer = new StringWriter();
+        try (InputStream esearchStream = entity.getContent()) {
+            IOUtils.copy(esearchStream, writer, "UTF-8");
+        }
+        return writer.toString();
+    }
+
+    /**
+     * Inspects the NCBI rate-limit response headers. Returns {@code true} (after sleeping for the
+     * advertised Retry-After interval) when the remaining quota is exhausted and the caller should
+     * replay the request. Header access is fully null/length guarded because NCBI omits these
+     * headers on error pages.
+     */
+    private boolean shouldRetryAfterRateLimit(CloseableHttpResponse response, String query) {
         Header[] headerRateLimitRemaining = response.getHeaders("X-RateLimit-Remaining");
         Header[] headerRateLimit = response.getHeaders("X-RateLimit-Limit");
         Header[] headerRetryAfter = response.getHeaders("Retry-After");
-        
-        log.info("Query : " + query  + " " + headerRateLimit[0].toString() + " " + headerRateLimitRemaining[0].toString());
-        
-        if(headerRateLimitRemaining != null && headerRateLimitRemaining.length > 0 && headerRateLimitRemaining[0] != null && Integer.parseInt(headerRateLimitRemaining[0].getValue()) == 0) {
-        	if(headerRetryAfter != null && headerRetryAfter.length > 0 && headerRetryAfter[0] != null) {
-        		log.info("Query : " + query  + " " + headerRetryAfter[0].toString());
-        		try {
-        			Thread.sleep(Long.parseLong(headerRetryAfter[0].getValue()) * 1000L);
-        		} catch (InterruptedException e) {
-        			log.error("InterruptedException", e);
-        		}
-        		response = httpClient.execute(httppost);
-        	}
-        }
-        
-		/*
-		 * Header[] headers = response.getAllHeaders(); for (Header header : headers) {
-		 * if(header.getName().equalsIgnoreCase("X-RateLimit-Limit") ||
-		 * header.getName().equalsIgnoreCase("X-RateLimit-Remaining") ||
-		 * header.getName().equalsIgnoreCase("Retry-After")) { log.info("Key : " +
-		 * header.getName() + " ,Value : " + header.getValue()); } }
-		 */
 
-        HttpEntity entity = response.getEntity();
-
-        if (entity != null) {
-            InputStream esearchStream = entity.getContent();
-			/*
-			 * StringWriter writer = new StringWriter(); IOUtils.copy(esearchStream, writer,
-			 * "UTF-8"); log.info(writer.toString());
-			 */
-            //SAXParserFactory.newInstance().newSAXParser().parse(esearchStream, pubmedESearchHandler);
-			JsonNode json = objectMapper.readTree(esearchStream).get("esearchresult");
-			if(json != null) {
-				eSearchResult = objectMapper.treeToValue(json, PubmedESearchResult.class);
-			}
+        if (headerRateLimit != null && headerRateLimit.length > 0 && headerRateLimit[0] != null
+                && headerRateLimitRemaining != null && headerRateLimitRemaining.length > 0 && headerRateLimitRemaining[0] != null) {
+            log.info("Query : " + query + " " + headerRateLimit[0].toString() + " " + headerRateLimitRemaining[0].toString());
         }
-        return eSearchResult;
+
+        if (headerRateLimitRemaining != null && headerRateLimitRemaining.length > 0 && headerRateLimitRemaining[0] != null
+                && Integer.parseInt(headerRateLimitRemaining[0].getValue()) == 0) {
+            if (headerRetryAfter != null && headerRetryAfter.length > 0 && headerRetryAfter[0] != null) {
+                log.info("Query : " + query + " " + headerRetryAfter[0].toString());
+                try {
+                    Thread.sleep(Long.parseLong(headerRetryAfter[0].getValue()) * 1000L);
+                } catch (InterruptedException e) {
+                    log.error("InterruptedException", e);
+                    Thread.currentThread().interrupt();
+                }
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean isValidAuthorString(String input) {
+        // Regular expression to match anything inside square brackets.
+        Pattern pattern = Pattern.compile("\\[(.*?)\\]");
+        Matcher matcher = pattern.matcher(input);
+        boolean containsAuthor = false;
+
+        while (matcher.find()) {
+            String matchedContent = matcher.group(1).trim(); // Get the content inside [].
+            // Check if the content is neither empty nor anything other than "Author".
+            if (!"Author".equals(matchedContent) && !"All Fields".equals(matchedContent)) {
+                return false; // Found something invalid inside [].
+            }
+            containsAuthor = true; // We found [Author].
+        }
+
+        // Return true if at least one [Author] exists, and no other value inside [].
+        return containsAuthor;
     }
 }

--- a/src/main/java/reciter/pubmed/xmlparser/PubmedESearchHandler.java
+++ b/src/main/java/reciter/pubmed/xmlparser/PubmedESearchHandler.java
@@ -1,33 +1,13 @@
 package reciter.pubmed.xmlparser;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.ArrayList;
-import java.util.List;
-
-import javax.xml.parsers.ParserConfigurationException;
-
 import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import org.apache.http.Header;
-import org.apache.http.HttpEntity;
-import org.apache.http.HttpResponse;
-import org.apache.http.NameValuePair;
-import org.apache.http.client.HttpClient;
-import org.apache.http.client.entity.UrlEncodedFormEntity;
-import org.apache.http.client.methods.HttpPost;
-import org.apache.http.client.params.ClientPNames;
-import org.apache.http.impl.client.HttpClients;
-import org.apache.http.message.BasicNameValuePair;
 import org.xml.sax.Attributes;
 import org.xml.sax.SAXException;
 import org.xml.sax.helpers.DefaultHandler;
 
 import lombok.extern.slf4j.Slf4j;
-import reciter.pubmed.model.PubmedESearchResult;
-import reciter.pubmed.querybuilder.PubmedXmlQuery;
 
 /**
  * A SAX handler for parsing the ESearch query from PubMed.
@@ -42,107 +22,10 @@ public class PubmedESearchHandler extends DefaultHandler {
     private boolean bWebEnv;
     private boolean bCount;
     private int numCountEncounteredSoFar = 0;
-    
+
     private static ObjectMapper objectMapper = new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 
     private StringBuilder chars = new StringBuilder();
-
-    /**
-     * Sends a query to the NCBI web site to retrieve the webEnv.
-     *
-     * @param eSearchUrl example query: http://www.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi?db=pubmed&retmax=1&usehistory=y&term=Kukafka%20R[au].
-     * @return WebEnvHandler that contains the WebEnv data.
-     * @throws ParserConfigurationException
-     * @throws SAXException
-     * @throws IOException
-     */
-    public static PubmedESearchResult executeESearchQuery(String eSearchUrl) {
-        PubmedESearchHandler webEnvHandler = new PubmedESearchHandler();
-        PubmedESearchResult eSearchResult = new PubmedESearchResult();
-        /*InputStream inputStream = null;
-        try {
-            inputStream = new URL(eSearchUrl).openStream();
-        } catch (IOException e) {
-            log.error("Error in executeESearchQuery", e);
-        }
-        try {
-            SAXParserFactory.newInstance().newSAXParser().parse(inputStream, webEnvHandler);
-        } catch (Exception e) {
-            log.error("Error in executeESearchQuery. url=[" + eSearchUrl + "]", e);
-        }*/
-        PubmedXmlQuery pubmedXmlQuery = new PubmedXmlQuery(eSearchUrl);
-        pubmedXmlQuery.setRetMax(1);
-        String fullUrl = pubmedXmlQuery.buildESearchQuery(); // build eSearch query.
-        log.info("ESearch Query=[" + fullUrl + "]");
-        if(pubmedXmlQuery.getApiKey() != null &&
-       		  !pubmedXmlQuery.getApiKey().isEmpty()) {
-        	fullUrl = PubmedXmlQuery.ESEARCH_BASE_URL + "?api_key=" + pubmedXmlQuery.getApiKey();
-	      } else {
-	      	fullUrl = PubmedXmlQuery.ESEARCH_BASE_URL;
-	      }
-
-        try {
-            HttpClient httpClient = HttpClients.createDefault();
-            HttpPost httppost = new HttpPost(fullUrl);
-            //httppost.setHeader(HttpHeaders.ACCEPT, "application/xml");
-            // Request parameters and other properties.
-            List<NameValuePair> params = new ArrayList<NameValuePair>();
-            params.add(new BasicNameValuePair("db", pubmedXmlQuery.getDb()));
-            params.add(new BasicNameValuePair("retmax", String.valueOf(pubmedXmlQuery.getRetMax())));
-            params.add(new BasicNameValuePair("usehistory", pubmedXmlQuery.getUseHistory()));
-            params.add(new BasicNameValuePair("term", java.net.URLDecoder.decode(pubmedXmlQuery.getTerm(), "UTF-8")));
-            params.add(new BasicNameValuePair("retmode", pubmedXmlQuery.getRetMode()));
-            params.add(new BasicNameValuePair("retstart", String.valueOf(pubmedXmlQuery.getRetStart())));
-            httppost.setEntity(new UrlEncodedFormEntity(params));
-            httppost.setHeader("Content-Type", "application/x-www-form-urlencoded");
-            httppost.getParams().setParameter(ClientPNames.COOKIE_POLICY, "standard");
-            //Execute and get the response.
-            
-            HttpResponse response = httpClient.execute(httppost);
-            Header[] headerRateLimitRemaining = response.getHeaders("X-RateLimit-Remaining");
-            Header[] headerRetryAfter = response.getHeaders("Retry-After");
-            
-            if(headerRateLimitRemaining != null && headerRateLimitRemaining.length > 0 && headerRateLimitRemaining[0] != null && Integer.parseInt(headerRateLimitRemaining[0].getValue()) == 0) {
-            	if(headerRetryAfter != null && headerRetryAfter.length > 0 && headerRetryAfter[0] != null) {
-            		try {
-            			Thread.sleep(Long.parseLong(headerRetryAfter[0].getValue()) * 1000L);
-            		} catch (InterruptedException e) {
-            			log.error("InterruptedException", e);
-            		}
-            		response = httpClient.execute(httppost);
-            	}
-            }
-            
-			/*
-			 * Header[] headers = response.getAllHeaders(); for (Header header : headers) {
-			 * if(header.getName().equalsIgnoreCase("X-RateLimit-Limit") ||
-			 * header.getName().equalsIgnoreCase("X-RateLimit-Remaining") ||
-			 * header.getName().equalsIgnoreCase("Retry-After")) { log.info("Key : " +
-			 * header.getName() + " ,Value : " + header.getValue()); } }
-			 */
-
-            HttpEntity entity = response.getEntity();
-
-            if (entity != null) {
-                InputStream esearchStream = entity.getContent();
-				/*
-				 * StringWriter writer = new StringWriter(); IOUtils.copy(esearchStream, writer,
-				 * "UTF-8"); log.info(writer.toString());
-				 */
-                //String sanitizedStream = IOUtils.toString(esearchStream).trim().replaceFirst("^([\\W]+)<","<");
-                //log.info(sanitizedStream);
-                //SAXParserFactory.newInstance().newSAXParser().parse(esearchStream, webEnvHandler);
-    			JsonNode json = objectMapper.readTree(esearchStream).get("esearchresult");
-    			if(json != null) {
-    				eSearchResult = objectMapper.treeToValue(json, PubmedESearchResult.class);
-    			}
-            }
-        } catch (IOException e) {
-            log.error("Error parsing XML file for query=[" + eSearchUrl + "], full url=[" + fullUrl + "]", e);
-        }
-
-        return eSearchResult;
-    }
 
     @Override
     public void startElement(String uri, String localName, String qName, Attributes attributes) throws SAXException {


### PR DESCRIPTION
## Summary

Hardens all outbound NCBI E-utilities HTTP handling and unifies the ESearch
logic shared between the count endpoint and the article-retrieval path. This is
a reliability + security pass; behavior for valid queries is unchanged, while
failure modes (stalled NCBI, missing rate-limit headers, dropped-term queries,
leaked secrets, XXE) are now contained.

Closes #107
Closes #108
Closes #109
Closes #110
Closes #111
Closes #114

## What changed and why

**#107 / #108 — Shared, pooled, timeout-bounded HTTP client**
- New `reciter.config.HttpClientConfig` exposes one `CloseableHttpClient` bean
  backed by a `PoolingHttpClientConnectionManager`, with `RequestConfig`
  timeouts (connect 5s, socket 60s, connection-request 5s). It is injected into
  `PubMedArticleRetrievalService`, replacing the per-request
  `HttpClients.createDefault()` calls in both the service and the controller.
- Response entities are now read inside try-with-resources (`CloseableHttpResponse`
  + entity `InputStream`), so connections/file descriptors are no longer leaked.
- The EFetch hot path (`PubMedUriParserCallable`) now sets connect/read timeouts
  on the `URLConnection` (5s/60s) and closes the stream, so a stalled EFetch can
  no longer wedge a worker thread indefinitely.

**#109 — Header guard, retry narrowing, recovery**
- The `X-RateLimit-*` header array access is now fully null/length guarded
  (same triad already used elsewhere), eliminating the
  `ArrayIndexOutOfBoundsException` that NCBI error pages could trigger.
- `@Retryable` on `retrieve(...)` is narrowed from `RuntimeException` to
  `IOException` (transient I/O), and a `@Recover` method is added.
- `future.get()` failures are no longer collapsed into a generic
  `IllegalStateException`; the underlying `IOException` is propagated so retry
  classification works. The executor is now always shut down in a `finally`.

**#110 — Unified ESearch + query-drop everywhere**
- Extracted a single `executeESearch(term)` helper in the service that performs
  the HTTP POST, rate-limit handling, and the Fix #24 query-drop detection
  (zeroing the count when PubMed silently drops a name part). Both the count
  endpoint (`/query-number-pubmed-articles/`) and the retrieval path
  (`/query/{query}`, `/query-complex/`) now call it, so dropped-term queries are
  neutralized on every path — previously only the count endpoint was protected.
- Removed the dead third ESearch copy (`PubmedESearchHandler.executeESearchQuery`)
  and its now-unused imports; the SAX handler itself is retained.

**#111 — Stop leaking the API key and full response bodies**
- Added `PubmedXmlQuery.redactApiKey(url)`; all `ESearch Query`/`eFetchUrl` INFO
  logs now pass the URL through it, so `api_key` is never written to logs.
- Removed the controller's full-upstream-response-body INFO log.

**#114 — XXE hardening**
- The `SAXParserFactory` now sets `disallow-doctype-decl=true`, disables external
  general/parameter entities, disables external DTD loading, and enables
  `FEATURE_SECURE_PROCESSING`.
- The EFetch fetch is restricted to the expected NCBI host (`www.ncbi.nlm.nih.gov`)
  as an SSRF guard on the SAX system-id.

Out of scope per the task: #117 (shared cross-thread rate limiter) is not attempted.

## Testing

- `export JAVA_HOME=...openjdk@11...; mvn -B -ntp clean package -DskipTests`
  → **BUILD SUCCESS** (jar built: `reciter-pubmed-retrieval-tool-1.1.0.jar`).
- `mvn -B -ntp test -Dtest=PubMedUriParserCallableTest,PubmedEFetchHandlerTest`
  → **Tests run: 6, Failures: 0, Errors: 0, Skipped: 0**. This confirms the
  XXE-hardened SAX factory still parses real NCBI EFetch XML and the callable's
  byte-stream path is unaffected.
- The live load tests (`LoadTest`, `ReCiterPubmedApiLoadTest`) were not run; they
  require a running service and 403 against NCBI without one.
