### PR TITLE
Add global exception handler and skip redundant Squiggly round-trip

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Temurin JDK 11
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '11'
+          cache: maven
+
+      # Build and run unit tests, but exclude the live load tests
+      # (ReCiterPubmedApiLoadTest / LoadTest) which require a running
+      # service on localhost:5000 and would otherwise fail the build.
+      - name: Build and test
+        run: mvn -B -ntp clean package -Dtest=PubmedEFetchHandlerTest,PubMedUriParserCallableTest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,20 @@
-FROM adoptopenjdk/openjdk11:alpine-jre
+FROM eclipse-temurin:11-jre-alpine
+
+# wget is used by the HEALTHCHECK below
+RUN apk add --no-cache wget
 
 RUN mkdir -p /app
 WORKDIR /app
 ARG JAR_FILE=target/*.jar
 COPY ${JAR_FILE} /app/app.jar
-# Comment this if you do not have NewRelic integration
-RUN wget https://download.newrelic.com/newrelic/java-agent/newrelic-agent/current/newrelic-java.zip && \
-    unzip newrelic-java.zip -d /app
+
+# Run as a non-root user (fixed UID/GID so it matches the k8s securityContext)
+RUN addgroup -S -g 10001 app && adduser -S -u 10001 -G app app && chown -R app:app /app
+USER 10001
+
 EXPOSE 5000
-CMD java -Djava.security.egd=file:/dev/./urandom -XX:+PrintFlagsFinal $JAVA_OPTIONS -jar /app/app.jar
+
+HEALTHCHECK --interval=30s --timeout=3s --start-period=30s --retries=3 \
+    CMD wget -q -O /dev/null http://localhost:5000/pubmed/ping || exit 1
+
+CMD java -Djava.security.egd=file:/dev/./urandom $JAVA_OPTIONS -jar /app/app.jar

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -18,4 +18,4 @@ services:
     working_dir: /app
     expose:
       - "5000"
-    command: mvn clean spring-boot:run
+    command: java -jar /app/app.jar

--- a/kubernetes/k8-deployment.yaml
+++ b/kubernetes/k8-deployment.yaml
@@ -28,10 +28,19 @@ spec:
         tier: backend
         owner: szd2013
     spec:
+      securityContext:
+        fsGroup: 10001
       containers:
         - image: CONTAINER_IMAGE
           name: reciter-pubmed
           imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            runAsUser: 10001
+            capabilities:
+              drop:
+                - ALL
           env:
             - name: PUBMED_API_KEY
               valueFrom:
@@ -53,7 +62,7 @@ spec:
               memory: 2.5G
               cpu: 1
             limits:
-              memory: 2.6G
+              memory: 3Gi
               cpu: 1
           livenessProbe:
             httpGet:
@@ -65,7 +74,7 @@ spec:
             timeoutSeconds: 3
           readinessProbe:
             httpGet:
-              path: "pubmed/ping"
+              path: "/pubmed/ping"
               port: 5000
             initialDelaySeconds: 20
             periodSeconds: 10

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.20</version>
+            <version>1.18.34</version>
             <scope>provided</scope>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.mockito/mockito-core -->

--- a/pom.xml
+++ b/pom.xml
@@ -50,11 +50,6 @@
 			<artifactId>springfox-boot-starter</artifactId>
 			<version>3.0.0</version>
 		</dependency>
-        <dependency>
-            <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk-dynamodb</artifactId>
-            <version>1.11.1009</version>
-        </dependency>
         <!-- https://mvnrepository.com/artifact/org.projectlombok/lombok -->
         <dependency>
             <groupId>org.projectlombok</groupId>
@@ -91,6 +86,7 @@
             <groupId>org.jsmart</groupId>
             <artifactId>zerocode-tdd</artifactId>
             <version>1.3.28</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.springframework.retry</groupId>

--- a/src/main/java/reciter/config/HttpClientConfig.java
+++ b/src/main/java/reciter/config/HttpClientConfig.java
@@ -1,0 +1,53 @@
+package reciter.config;
+
+import org.apache.http.client.config.CookieSpecs;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Provides a single shared, pooled, timeout-bounded {@link CloseableHttpClient} for all
+ * outbound calls to the NCBI E-utilities API.
+ *
+ * <p>Using one pooled client (instead of {@code HttpClients.createDefault()} per request)
+ * allows TCP/TLS connection reuse and prevents connection/file-descriptor leaks under load.
+ * The {@link RequestConfig} timeouts ensure a slow or stalled NCBI response can never wedge
+ * a servlet worker thread indefinitely.
+ */
+@Configuration
+public class HttpClientConfig {
+
+    /** Time to establish a TCP connection to NCBI. */
+    private static final int CONNECT_TIMEOUT_MILLIS = 5_000;
+
+    /** Time to wait between data packets once connected (read timeout). */
+    private static final int SOCKET_TIMEOUT_MILLIS = 60_000;
+
+    /** Time to wait for a connection from the pool. */
+    private static final int CONNECTION_REQUEST_TIMEOUT_MILLIS = 5_000;
+
+    private static final int MAX_TOTAL_CONNECTIONS = 50;
+    private static final int MAX_CONNECTIONS_PER_ROUTE = 50;
+
+    @Bean(destroyMethod = "close")
+    public CloseableHttpClient pubMedHttpClient() {
+        PoolingHttpClientConnectionManager connectionManager = new PoolingHttpClientConnectionManager();
+        connectionManager.setMaxTotal(MAX_TOTAL_CONNECTIONS);
+        connectionManager.setDefaultMaxPerRoute(MAX_CONNECTIONS_PER_ROUTE);
+
+        RequestConfig requestConfig = RequestConfig.custom()
+                .setConnectTimeout(CONNECT_TIMEOUT_MILLIS)
+                .setSocketTimeout(SOCKET_TIMEOUT_MILLIS)
+                .setConnectionRequestTimeout(CONNECTION_REQUEST_TIMEOUT_MILLIS)
+                .setCookieSpec(CookieSpecs.STANDARD)
+                .build();
+
+        return HttpClients.custom()
+                .setConnectionManager(connectionManager)
+                .setDefaultRequestConfig(requestConfig)
+                .build();
+    }
+}

--- a/src/main/java/reciter/controller/GlobalExceptionHandler.java
+++ b/src/main/java/reciter/controller/GlobalExceptionHandler.java
@@ -1,0 +1,57 @@
+package reciter.controller;
+
+import java.io.IOException;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Global exception handler producing clean JSON error responses without leaking stack traces
+ * or internal exception detail to clients. Stack traces are logged server-side only.
+ *
+ * <p>The threshold-exceeded case (thrown as an {@link IOException} by
+ * {@code PubMedArticleRetrievalService.retrieve} when the matching article count exceeds the
+ * retrieval threshold) is mapped to {@code 502 Bad Gateway} with a small {@code {error, message}}
+ * body so callers can distinguish it from a generic failure. All other uncaught exceptions are
+ * mapped to a generic {@code 500 Internal Server Error} body with no internal detail.
+ */
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    /** Marker substring identifying the threshold-exceeded IOException message. */
+    private static final String THRESHOLD_EXCEEDED_MARKER = "exceeded the threshold level";
+
+    @ExceptionHandler(IOException.class)
+    public ResponseEntity<Map<String, Object>> handleIOException(IOException ex) {
+        String message = ex.getMessage();
+        if (message != null && message.contains(THRESHOLD_EXCEEDED_MARKER)) {
+            log.warn("PubMed retrieval threshold exceeded: {}", message);
+            return errorResponse(HttpStatus.BAD_GATEWAY, "threshold_exceeded",
+                    "The query matched too many PubMed articles to retrieve. Please refine the query.");
+        }
+        log.error("Upstream PubMed retrieval error.", ex);
+        return errorResponse(HttpStatus.BAD_GATEWAY, "upstream_error",
+                "Unable to retrieve results from PubMed at this time.");
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<Map<String, Object>> handleException(Exception ex) {
+        log.error("Unhandled exception while processing request.", ex);
+        return errorResponse(HttpStatus.INTERNAL_SERVER_ERROR, "internal_error",
+                "An unexpected error occurred while processing the request.");
+    }
+
+    private static ResponseEntity<Map<String, Object>> errorResponse(HttpStatus status, String error, String message) {
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("error", error);
+        body.put("message", message);
+        return ResponseEntity.status(status).body(body);
+    }
+}

--- a/src/main/java/reciter/controller/PubMedRetrievalToolController.java
+++ b/src/main/java/reciter/controller/PubMedRetrievalToolController.java
@@ -1,35 +1,17 @@
 package reciter.controller;
 
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.StringWriter;
 import java.net.URLEncoder;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.bohnman.squiggly.Squiggly;
 import com.github.bohnman.squiggly.util.SquigglyUtils;
 
-import org.apache.commons.io.IOUtils;
-import org.apache.http.Header;
-import org.apache.http.HttpEntity;
-import org.apache.http.HttpResponse;
-import org.apache.http.NameValuePair;
-import org.apache.http.client.HttpClient;
-import org.apache.http.client.entity.UrlEncodedFormEntity;
-import org.apache.http.client.methods.HttpPost;
-import org.apache.http.client.params.ClientPNames;
-import org.apache.http.impl.client.HttpClients;
-import org.apache.http.message.BasicNameValuePair;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
@@ -47,8 +29,6 @@ import io.swagger.annotations.ApiResponses;
 import lombok.extern.slf4j.Slf4j;
 import reciter.model.pubmed.PubMedArticle;
 import reciter.pubmed.model.PubMedQuery;
-import reciter.pubmed.model.PubmedESearchResult;
-import reciter.pubmed.querybuilder.PubmedXmlQuery;
 import reciter.pubmed.retriever.PubMedArticleRetrievalService;
 
 @Slf4j
@@ -59,8 +39,6 @@ public class PubMedRetrievalToolController {
 
     @Autowired
     private PubMedArticleRetrievalService pubMedArticleRetrievalService;
-    
-    private static ObjectMapper objectMapper = new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 
     @ApiOperation(value = "Query with field selection.", response = List.class)
     @ApiResponses(value = {
@@ -93,140 +71,12 @@ public class PubMedRetrievalToolController {
     @RequestMapping(value = "/query-number-pubmed-articles/", method = RequestMethod.POST)
     @ResponseBody
     public int getNumberOfPubMedArticles(@RequestBody PubMedQuery pubMedQuery) throws IOException {
-    	
-        PubmedXmlQuery pubmedXmlQuery = new PubmedXmlQuery(URLEncoder.encode(pubMedQuery.toString(), "UTF-8"));
-        //pubmedXmlQuery.setRetMax(1);
-        pubmedXmlQuery.setRetStart(0);
-        String fullUrl = pubmedXmlQuery.buildESearchQuery(); // build eSearch query.
-        log.info("ESearch Query=[" + fullUrl + "]");
-        //PubmedESearchHandler pubmedESearchHandler = new PubmedESearchHandler();
-        PubmedESearchResult eSearchResult = new PubmedESearchResult();
-        HttpClient httpClient = HttpClients.createDefault();
-        if(pubmedXmlQuery.getApiKey() != null &&
-       		  !pubmedXmlQuery.getApiKey().isEmpty()) {
-        	fullUrl = PubmedXmlQuery.ESEARCH_BASE_URL + "?api_key=" + pubmedXmlQuery.getApiKey();
-        } else {
-        	fullUrl = PubmedXmlQuery.ESEARCH_BASE_URL;
-        }
-        
-        HttpPost httppost = new HttpPost(fullUrl);
-        // Request parameters and other properties.
-        List<NameValuePair> params = new ArrayList<>();
-        params.add(new BasicNameValuePair("db", pubmedXmlQuery.getDb()));
-        params.add(new BasicNameValuePair("retmax", String.valueOf(pubmedXmlQuery.getRetMax())));
-        params.add(new BasicNameValuePair("usehistory", pubmedXmlQuery.getUseHistory()));
-        params.add(new BasicNameValuePair("term", java.net.URLDecoder.decode(pubmedXmlQuery.getTerm(), "UTF-8")));
-        params.add(new BasicNameValuePair("retmode", pubmedXmlQuery.getRetMode()));
-        params.add(new BasicNameValuePair("retstart", String.valueOf(pubmedXmlQuery.getRetStart())));
-        httppost.setEntity(new UrlEncodedFormEntity(params));
-        httppost.setHeader("Content-Type", "application/x-www-form-urlencoded");
-        httppost.getParams().setParameter(ClientPNames.COOKIE_POLICY, "standard");
-        httppost.setHeader("cache-control", "no-cache");
-
-        //Execute and get the response.
-        
-        HttpResponse response = httpClient.execute(httppost);
-        
-        Header[] headerRateLimitRemaining = response.getHeaders("X-RateLimit-Remaining");
-        Header[] headerRateLimit = response.getHeaders("X-RateLimit-Limit");
-        Header[] headerRetryAfter = response.getHeaders("Retry-After");
-        
-        if(pubMedQuery!=null && headerRateLimit!=null && headerRateLimit.length > 0 && headerRateLimit[0]!=null 
-        		&& headerRateLimitRemaining!=null && headerRateLimitRemaining.length >0 && headerRateLimitRemaining[0]!=null)
-        log.info("Query : " + pubMedQuery.toString()  + " " + headerRateLimit[0].toString() + " " + headerRateLimitRemaining[0].toString());
-        
-        if(headerRateLimitRemaining != null && headerRateLimitRemaining.length > 0 && headerRateLimitRemaining[0] != null && Integer.parseInt(headerRateLimitRemaining[0].getValue()) == 0) {
-        	if(headerRetryAfter != null && headerRetryAfter.length > 0 && headerRetryAfter[0] != null) {
-        		log.info("Query : " + pubMedQuery.toString()  + " " + headerRetryAfter[0].toString());
-        		try {
-        			Thread.sleep(Long.parseLong(headerRetryAfter[0].getValue()) * 1000L);
-        		} catch (InterruptedException e) {
-        			log.error("InterruptedException", e);
-        		}
-        		response = httpClient.execute(httppost);
-        	}
-        }
-		/*
-		 * for (Header header : headers) {
-		 * if(header.getName().equalsIgnoreCase("X-RateLimit-Limit") ||
-		 * header.getName().equalsIgnoreCase("X-RateLimit-Remaining") ||
-		 * header.getName().equalsIgnoreCase("Retry-After")) { log.info("Key : " +
-		 * header.getName() + " ,Value : " + header.getValue()); } }
-		 */
-        HttpEntity entity = response.getEntity();
-        if (entity != null) {
-            InputStream esearchStream = entity.getContent();
-			
-			  StringWriter writer = new StringWriter(); 
-			  IOUtils.copy(esearchStream, writer,"UTF-8"); 
-			  log.info(writer.toString());
-			  String responseString = writer.toString();
-            //SAXParserFactory.newInstance().newSAXParser().parse(esearchStream, pubmedESearchHandler);
-			if (responseString!=null && !responseString.equalsIgnoreCase("") && responseString.trim().startsWith("{") && objectMapper.readTree(responseString).has("esearchresult")) 
-			{  
-		            JsonNode json = objectMapper.readTree(responseString).get("esearchresult");
-		            log.info("PubMed Response Json:",json);
-		
-		            // Extract the "querytranslation" field
-			         String queryTranslation = json.path("querytranslation").asText();
-			         log.info("query translation prior to processing:",queryTranslation);
-			         // Check if the string contains [Affiliation], if it does, stop processing
-			         if (isValidAuthorString(queryTranslation)) {
-			        	 log.info("Entered into process firstNameInitial stragey query");
-			        	 
-			             // Split the string by [Author] and process each part
-			             List<String> segments = //Arrays.stream(queryTranslation.split("(?<=\\[Author\\])")) // Split the string by [Author]
-				            		 			 Arrays.stream(queryTranslation.split("\\[Author\\]")) // Split by [Author]
-				                                       .map(String::trim)  // Trim spaces around each part
-			                                           .map(part -> part.replaceAll("\\b(AND|OR)\\b", ""))  // Remove "AND" and "OR"
-			                                           .map(part -> part.replaceAll("\\s", ""))  // Remove all spaces
-			                                           .filter(part -> !part.isEmpty())  // Filter out empty parts
-			                                           .collect(Collectors.toList());
-			         
-			             // Flag to check if we found a valid segment (length > 2)
-			             boolean isValidSegmentFound = false;
-		
-			             // Iterate over each segment
-			             for (String part : segments) {
-			                 if (part.length() > 2) {
-			                     isValidSegmentFound = true; // We found a valid segment
-			                     break;  // Once we find a valid part, we stop further checks and proceed
-			                 }
-			             }
-			             
-			             
-			             // After the loop, if no valid segment was found, throw an exception
-			             if (!isValidSegmentFound) {
-			            	 log.error("No First Name initial found with more than 2 letters.Hence ignoring the " + eSearchResult.getCount() + "records returned from the PubMed");
-			            	 eSearchResult.setCount(0);
-			                 
-			             }
-			             else
-			             {
-			            	 if(json != null) {
-				     				eSearchResult = objectMapper.treeToValue(json, PubmedESearchResult.class);
-				     				log.info("eSearchResult count for the firstNameInitial strategy :",eSearchResult.getCount());
-				     			} 
-			             }
-			         }
-			         else
-			         {	 
-						if(json !=  null) {
-							eSearchResult = objectMapper.treeToValue(json, PubmedESearchResult.class);
-						}
-			         }
-		        
-		        log.info("esearchResults Count :"+eSearchResult.getCount());
-		        return eSearchResult.getCount();
-          }
-		  else
-		  {
-			  log.error("Unexpected response (not JSON), possibly an HTML error page.");
-			  return 0;
-		  }
-				
-        }
-        return 0;
+        // Delegate to the shared ESearch helper so query-drop detection, rate-limit handling,
+        // and HTTP/timeout behavior are identical to the article-retrieval path.
+        String encodedTerm = URLEncoder.encode(pubMedQuery.toString(), "UTF-8");
+        int count = pubMedArticleRetrievalService.getNumberOfPubMedArticles(encodedTerm).getCount();
+        log.info("esearchResults Count :" + count);
+        return count;
     }
 
     private List<PubMedArticle> retrieve(String query, String fields) throws IOException {
@@ -255,25 +105,5 @@ public class PubMedRetrievalToolController {
         });
         log.info("retrieved " + pubMedArticles.size() + " PubMed articles using query=[" + query + "]");
         return result;
-    }
-    private static boolean isValidAuthorString(String input) {
-        // Regular expression to match anything inside square brackets
-        Pattern pattern = Pattern.compile("\\[(.*?)\\]");
-        
-        Matcher matcher = pattern.matcher(input);
-        boolean containsAuthor = false;
-
-        while (matcher.find()) {
-            String matchedContent = matcher.group(1).trim(); // Get the content inside []
-
-            // Check if the content is neither empty nor anything other than "Author"
-            if (!"Author".equals(matchedContent) && !"All Fields".equals(matchedContent)) {
-                return false; // Found something invalid inside []
-            }
-            containsAuthor = true; // We found [Author]
-        }
-
-        // Return true if at least one [Author] exists, and no other value inside []
-        return containsAuthor;
     }
 }

--- a/src/main/java/reciter/controller/PubMedRetrievalToolController.java
+++ b/src/main/java/reciter/controller/PubMedRetrievalToolController.java
@@ -82,9 +82,17 @@ public class PubMedRetrievalToolController {
     private List<PubMedArticle> retrieve(String query, String fields) throws IOException {
         query = URLEncoder.encode(query, "UTF-8");
         log.info("Retrieving with query=[" + query + "]");
-        if (fields != null && !fields.isEmpty()) {
-            fields = fields.toLowerCase();
+
+        List<PubMedArticle> pubMedArticles = pubMedArticleRetrievalService.retrieve(query);
+        log.info("retrieved " + pubMedArticles.size() + " PubMed articles using query=[" + query + "]");
+
+        // No field selection requested: return the retrieved articles directly and skip the
+        // per-article Squiggly stringify -> readValue round-trip entirely.
+        if (fields == null || fields.isEmpty()) {
+            return new ArrayList<>(pubMedArticles);
         }
+
+        fields = fields.toLowerCase();
         ObjectMapper objectMapper = Squiggly
                 .init(new ObjectMapper(), fields)
                 .configure(MapperFeature.ACCEPT_CASE_INSENSITIVE_PROPERTIES, true)
@@ -92,18 +100,15 @@ public class PubMedRetrievalToolController {
                 .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
 
         List<PubMedArticle> result = new ArrayList<>();
-        List<PubMedArticle> pubMedArticles = pubMedArticleRetrievalService.retrieve(query);
         pubMedArticles.forEach(elem -> {
             String partialObject = SquigglyUtils.stringify(objectMapper, elem);
-            PubMedArticle pubMedArticle = null;
             try {
-                pubMedArticle = objectMapper.readValue(partialObject, PubMedArticle.class);
+                // On a per-item serialization failure, skip the element rather than adding null.
+                result.add(objectMapper.readValue(partialObject, PubMedArticle.class));
             } catch (IOException e) {
                 log.error("Unable to read value from pmid=" + elem.getMedlinecitation().getMedlinecitationpmid().getPmid(), e);
             }
-            result.add(pubMedArticle);
         });
-        log.info("retrieved " + pubMedArticles.size() + " PubMed articles using query=[" + query + "]");
         return result;
     }
 }

--- a/src/main/java/reciter/pubmed/callable/PubMedUriParserCallable.java
+++ b/src/main/java/reciter/pubmed/callable/PubMedUriParserCallable.java
@@ -1,6 +1,5 @@
 package reciter.pubmed.callable;
 
-import com.amazonaws.util.IOUtils;
 import lombok.AllArgsConstructor;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
@@ -12,6 +11,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringReader;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.concurrent.Callable;
 
@@ -40,7 +40,7 @@ public class PubMedUriParserCallable implements Callable<List<PubMedArticle>> {
         } else {
             inputStream = inputSource.getByteStream();
         }
-        String xml = IOUtils.toString(inputStream);
+        String xml = new String(inputStream.readAllBytes(), StandardCharsets.UTF_8);
         xml = xml.replace("<sup>", "&lt;sup&gt;");
         xml = xml.replace("</sup>", "&lt;/sup&gt;");
         xml = xml.replace("<sub>", "&lt;sub&gt;");

--- a/src/main/java/reciter/pubmed/callable/PubMedUriParserCallable.java
+++ b/src/main/java/reciter/pubmed/callable/PubMedUriParserCallable.java
@@ -12,11 +12,21 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringReader;
 import java.net.URL;
+import java.net.URLConnection;
 import java.util.List;
 import java.util.concurrent.Callable;
 
 @AllArgsConstructor
 public class PubMedUriParserCallable implements Callable<List<PubMedArticle>> {
+
+    /** Time to establish a TCP connection to NCBI for the EFetch fetch. */
+    private static final int CONNECT_TIMEOUT_MILLIS = 5_000;
+
+    /** Read timeout once connected, so a stalled EFetch response can never wedge a worker thread. */
+    private static final int READ_TIMEOUT_MILLIS = 60_000;
+
+    /** Only the NCBI E-utilities host may be fetched (SSRF guard on the SAX system-id). */
+    private static final String EXPECTED_HOST = "www.ncbi.nlm.nih.gov";
 
     private final PubmedEFetchHandler xmlHandler;
     private final SAXParser saxParser;
@@ -34,13 +44,21 @@ public class PubMedUriParserCallable implements Callable<List<PubMedArticle>> {
     }
 
     private InputSource preprocessSpecialCharacters(InputSource inputSource) throws IOException {
-        InputStream inputStream;
+        String xml;
         if (inputSource.getSystemId() != null) {
-            inputStream = new URL(inputSource.getSystemId()).openStream();
+            URL url = new URL(inputSource.getSystemId());
+            if (!EXPECTED_HOST.equalsIgnoreCase(url.getHost())) {
+                throw new IOException("Refusing to fetch EFetch XML from unexpected host: " + url.getHost());
+            }
+            URLConnection connection = url.openConnection();
+            connection.setConnectTimeout(CONNECT_TIMEOUT_MILLIS);
+            connection.setReadTimeout(READ_TIMEOUT_MILLIS);
+            try (InputStream inputStream = connection.getInputStream()) {
+                xml = IOUtils.toString(inputStream);
+            }
         } else {
-            inputStream = inputSource.getByteStream();
+            xml = IOUtils.toString(inputSource.getByteStream());
         }
-        String xml = IOUtils.toString(inputStream);
         xml = xml.replace("<sup>", "&lt;sup&gt;");
         xml = xml.replace("</sup>", "&lt;/sup&gt;");
         xml = xml.replace("<sub>", "&lt;sub&gt;");

--- a/src/main/java/reciter/pubmed/querybuilder/PubmedXmlQuery.java
+++ b/src/main/java/reciter/pubmed/querybuilder/PubmedXmlQuery.java
@@ -148,7 +148,22 @@ public class PubmedXmlQuery {
         sb.append("xml");               
         sb.append("&WebEnv=");
         sb.append(webEnv);
-        
+
         return sb.toString();
+    }
+
+    /**
+     * Redacts the {@code api_key} value from a query URL so that the NCBI API key is never
+     * written to logs. The key value is replaced with {@code REDACTED} while preserving the
+     * rest of the URL for debugging.
+     *
+     * @param url a query URL that may contain an {@code api_key} parameter
+     * @return the URL with the api_key value redacted, or {@code null} if the input was null
+     */
+    public static String redactApiKey(String url) {
+        if (url == null) {
+            return null;
+        }
+        return url.replaceAll("(?i)(api_key=)[^&]*", "$1REDACTED");
     }
 }

--- a/src/main/java/reciter/pubmed/retriever/PubMedArticleRetrievalService.java
+++ b/src/main/java/reciter/pubmed/retriever/PubMedArticleRetrievalService.java
@@ -4,15 +4,11 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringWriter;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 import javax.xml.XMLConstants;
 import javax.xml.parsers.ParserConfigurationException;
@@ -263,31 +259,10 @@ public class PubMedArticleRetrievalService {
             return eSearchResult;
         }
 
-        // Extract the "querytranslation" field and apply query-drop detection.
-        String queryTranslation = json.path("querytranslation").asText();
-        if (isValidAuthorString(queryTranslation)) {
-            log.info("Entered into process firstNameInitial strategy query");
-            // Split the string by [Author] and process each part.
-            List<String> segments = Arrays.stream(queryTranslation.split("\\[Author\\]"))
-                    .map(String::trim)
-                    .map(part -> part.replaceAll("\\b(AND|OR)\\b", ""))
-                    .map(part -> part.replaceAll("\\s", ""))
-                    .filter(part -> !part.isEmpty())
-                    .collect(Collectors.toList());
-
-            boolean isValidSegmentFound = false;
-            for (String part : segments) {
-                if (part.length() > 2) {
-                    isValidSegmentFound = true;
-                    break;
-                }
-            }
-
-            if (!isValidSegmentFound) {
-                log.error("No First Name initial found with more than 2 letters. Hence ignoring the records returned from PubMed for query=[{}].", term);
-                eSearchResult.setCount(0);
-                return eSearchResult;
-            }
+        // Query-drop detection (Fix #24): only act when PubMed actually reports dropped
+        // phrases (errorlist.phrasenotfound) leaving a trivial query; then discard the noise.
+        if (isPubMedQueryDropped(json, term)) {
+            return eSearchResult; // count stays 0
         }
 
         eSearchResult = objectMapper.treeToValue(json, PubmedESearchResult.class);
@@ -356,22 +331,34 @@ public class PubMedArticleRetrievalService {
         return false;
     }
 
-    private static boolean isValidAuthorString(String input) {
-        // Regular expression to match anything inside square brackets.
-        Pattern pattern = Pattern.compile("\\[(.*?)\\]");
-        Matcher matcher = pattern.matcher(input);
-        boolean containsAuthor = false;
-
-        while (matcher.find()) {
-            String matchedContent = matcher.group(1).trim(); // Get the content inside [].
-            // Check if the content is neither empty nor anything other than "Author".
-            if (!"Author".equals(matchedContent) && !"All Fields".equals(matchedContent)) {
-                return false; // Found something invalid inside [].
-            }
-            containsAuthor = true; // We found [Author].
+    /**
+     * Query-drop detection (Fix #24). PubMed silently drops unrecognized name parts
+     * (e.g. "Charles-rawlins J[au]" becomes "J[au]"), returning many irrelevant results.
+     * Detect this via PubMed's authoritative {@code errorlist.phrasenotfound} signal: only if it
+     * reports dropped phrases AND the remaining {@code querytranslation} is trivially short
+     * (<= 2 chars after stripping field tags, boolean operators and punctuation) are the results
+     * treated as noise. This avoids false positives on legitimately short author queries.
+     *
+     * @param esearchJson   the "esearchresult" JSON node from PubMed's ESearch response
+     * @param originalQuery the original query term (for logging)
+     * @return true if the query was dropped and the results should be discarded
+     */
+    protected static boolean isPubMedQueryDropped(JsonNode esearchJson, String originalQuery) {
+        JsonNode phraseNotFound = esearchJson.path("errorlist").path("phrasenotfound");
+        if (!phraseNotFound.isArray() || phraseNotFound.size() == 0) {
+            return false; // PubMed did not drop any phrases.
         }
-
-        // Return true if at least one [Author] exists, and no other value inside [].
-        return containsAuthor;
+        String queryTranslation = esearchJson.path("querytranslation").asText("");
+        String stripped = queryTranslation
+                .replaceAll("\\[(?:Author|au|All Fields)\\]", "")
+                .replaceAll("\\b(AND|OR)\\b", "")
+                .replaceAll("[()\"\\s]", "")
+                .trim();
+        if (stripped.length() <= 2) {
+            log.warn("PubMed dropped query terms {} from query [{}]. QueryTranslation='{}' is trivial (stripped='{}'). Returning 0 results.",
+                    phraseNotFound, originalQuery, queryTranslation, stripped);
+            return true;
+        }
+        return false;
     }
 }

--- a/src/main/java/reciter/pubmed/retriever/PubMedArticleRetrievalService.java
+++ b/src/main/java/reciter/pubmed/retriever/PubMedArticleRetrievalService.java
@@ -2,12 +2,19 @@ package reciter.pubmed.retriever;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.StringWriter;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
+import javax.xml.XMLConstants;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.parsers.SAXParser;
 import javax.xml.parsers.SAXParserFactory;
@@ -16,17 +23,18 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import org.apache.commons.io.IOUtils;
 import org.apache.http.Header;
 import org.apache.http.HttpEntity;
-import org.apache.http.HttpResponse;
 import org.apache.http.NameValuePair;
-import org.apache.http.client.HttpClient;
 import org.apache.http.client.entity.UrlEncodedFormEntity;
+import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpPost;
-import org.apache.http.client.params.ClientPNames;
-import org.apache.http.impl.client.HttpClients;
+import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.message.BasicNameValuePair;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Recover;
 import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Service;
 import org.xml.sax.InputSource;
@@ -44,8 +52,11 @@ import reciter.pubmed.xmlparser.PubmedEFetchHandler;
 public class PubMedArticleRetrievalService {
 
     private static final int RETRIEVAL_THRESHOLD = 2000;
-    
+
     private static ObjectMapper objectMapper = new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+
+    @Autowired
+    private CloseableHttpClient pubMedHttpClient;
 
     /*@Autowired
     private SAXParser saxParser;
@@ -54,19 +65,27 @@ public class PubMedArticleRetrievalService {
     public SAXParser saxParser() throws ParserConfigurationException, SAXException {
         return SAXParserFactory.newInstance().newSAXParser();
     }*/
-    
+
     //To avoid thread errors - FWK005 parse may not be called while parsing.
     //https://stackoverflow.com/questions/39658247/singleton-thread-safe-sax-parser-instance
     private final ThreadLocal<SAXParserFactory> factoryThreadLocal = new ThreadLocal<SAXParserFactory>() {
         public SAXParserFactory initialValue() {
             try {
-                return SAXParserFactory.newInstance();
+                SAXParserFactory factory = SAXParserFactory.newInstance();
+                // Harden against XXE: disallow DOCTYPE declarations and disable external
+                // entity/DTD resolution. This is defense-in-depth for an XML-parsing service.
+                factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+                factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+                factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+                factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+                factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+                return factory;
             } catch (Exception e) {
                 throw new RuntimeException(e);
             }
         }
    };
-   
+
    public SAXParser getSaxParser() throws ParserConfigurationException, SAXException {
 	   return factoryThreadLocal.get().newSAXParser();
    }
@@ -75,10 +94,10 @@ public class PubMedArticleRetrievalService {
      * Initializes and starts threads that handles the retrieval process. Partition the number of articles
      * into manageable pieces and ask each thread to handle one partition.
      */
-    @Retryable(maxAttempts = 7, value = RuntimeException.class, 
+    @Retryable(maxAttempts = 7, value = IOException.class,
         backoff = @Backoff(random = true, delay = 1500, maxDelay = 9000), listeners = {"retryListener"})
     public List<PubMedArticle> retrieve(String pubMedQuery) throws IOException {
-    	
+
     	PubmedESearchResult eSearchResult = new PubmedESearchResult();
     	eSearchResult = getNumberOfPubMedArticles(pubMedQuery);
 
@@ -88,7 +107,7 @@ public class PubMedArticleRetrievalService {
         if (numberOfPubmedArticles <= RETRIEVAL_THRESHOLD) {
             ExecutorService executor = Executors.newWorkStealingPool();
         	//ScheduledExecutorService executor = (ScheduledExecutorService) Executors.newScheduledThreadPool(10);
-        	
+
 
             // Get the count (number of publications for this query).
             PubmedXmlQuery pubmedXmlQuery = new PubmedXmlQuery();
@@ -109,8 +128,8 @@ public class PubMedArticleRetrievalService {
 
             //List<RetryerCallable<List<PubMedArticle>>> callables = new ArrayList<RetryerCallable<List<PubMedArticle>>>();
             List<Callable<List<PubMedArticle>>> callables = new ArrayList<>();
-            
-            
+
+
 
             // Use the retstart value to iteratively fetch all XMLs.
             while (numberOfPubmedArticles > 0) {
@@ -125,9 +144,9 @@ public class PubMedArticleRetrievalService {
 
                 // Use the webenv value to retrieve xml.
                 String eFetchUrl = pubmedXmlQuery.buildEFetchQuery();
-                log.info("eFetchUrl=[{}].", eFetchUrl);
-                
-                
+                log.info("eFetchUrl=[{}].", PubmedXmlQuery.redactApiKey(eFetchUrl));
+
+
 
                 try {
                 	//PubMedUriParserCallable callable = new PubMedUriParserCallable(new PubmedEFetchHandler(), getSaxParser(), new InputSource(eFetchUrl));
@@ -143,27 +162,33 @@ public class PubMedArticleRetrievalService {
                 pubmedXmlQuery.setRetStart(currentRetStart);
                 numberOfPubmedArticles -= pubmedXmlQuery.getRetMax();
             }
-            
-			
+
+
 			/*
 			 * for(Callable<List<PubMedArticle>> callable: callables) {
 			 * executor.schedule(callable, 5, TimeUnit.SECONDS); }
 			 */
-			 
+
 
             try {
-                executor.invokeAll(callables)
-                        .stream()
-                        .map(future -> {
-                            try {
-                                return future.get();
-                            } catch (Exception e) {
-                                log.error("Unable to retrieve result using future get.");
-                                throw new IllegalStateException(e);
-                            }
-                        }).forEach(pubMedArticles::addAll);
+                List<java.util.concurrent.Future<List<PubMedArticle>>> futures = executor.invokeAll(callables);
+                for (java.util.concurrent.Future<List<PubMedArticle>> future : futures) {
+                    try {
+                        pubMedArticles.addAll(future.get());
+                    } catch (ExecutionException e) {
+                        log.error("Unable to retrieve result using future get.");
+                        Throwable cause = e.getCause();
+                        if (cause instanceof IOException) {
+                            throw (IOException) cause;
+                        }
+                        throw new IOException("Failed to fetch/parse EFetch result", cause);
+                    }
+                }
             } catch (InterruptedException e) {
                 log.error("Unable to invoke callable.", e);
+                Thread.currentThread().interrupt();
+            } finally {
+                executor.shutdownNow();
             }
         } else {
             throw new IOException("Number of PubMed Articles retrieved " + numberOfPubmedArticles + " exceeded the threshold level " + RETRIEVAL_THRESHOLD);
@@ -171,25 +196,47 @@ public class PubMedArticleRetrievalService {
         return pubMedArticles;
     }
 
-    protected PubmedESearchResult getNumberOfPubMedArticles(String query) throws IOException {
-        PubmedXmlQuery pubmedXmlQuery = new PubmedXmlQuery(query);
-        //pubmedXmlQuery.setRetMax(1);
-        String fullUrl = pubmedXmlQuery.buildESearchQuery(); // build eSearch query.
-        log.info("ESearch Query=[{}]", fullUrl);
-        
-        if(pubmedXmlQuery.getApiKey() != null &&
-         		  !pubmedXmlQuery.getApiKey().isEmpty()) {
-          	fullUrl = PubmedXmlQuery.ESEARCH_BASE_URL + "?api_key=" + pubmedXmlQuery.getApiKey();
-	      } else {
-	      	fullUrl = PubmedXmlQuery.ESEARCH_BASE_URL;
-	      }
+    /**
+     * Recovery handler invoked when {@link #retrieve(String)} exhausts all retry attempts.
+     * Re-throws the final exception rather than silently swallowing it so callers still see
+     * the failure, but provides a single, well-defined termination point for the retry loop.
+     */
+    @Recover
+    public List<PubMedArticle> recoverRetrieve(IOException e, String pubMedQuery) throws IOException {
+        log.error("Exhausted retries retrieving PubMed articles for query=[{}].", pubMedQuery, e);
+        throw e;
+    }
 
-        //PubmedESearchHandler pubmedESearchHandler = new PubmedESearchHandler();
+    public PubmedESearchResult getNumberOfPubMedArticles(String query) throws IOException {
+        return executeESearch(query);
+    }
+
+    /**
+     * Executes a single ESearch request against NCBI via HTTP POST. Handles rate-limit headers
+     * (sleeping and retrying once when the remaining quota is exhausted) and applies the
+     * query-drop detection (Fix #24): when PubMed silently drops a name part leaving a trivial
+     * author query, the returned count is zeroed so dropped-term queries are neutralized on
+     * every code path that performs an ESearch (both the count endpoint and the retrieval path).
+     *
+     * @param term URL-encoded Entrez query term (as stored in {@link PubmedXmlQuery#getTerm()})
+     * @return the parsed {@link PubmedESearchResult}; count is 0 for trivial/dropped queries or
+     *         non-JSON (e.g. HTML error page) responses.
+     */
+    protected PubmedESearchResult executeESearch(String term) throws IOException {
+        PubmedXmlQuery pubmedXmlQuery = new PubmedXmlQuery(term);
+        pubmedXmlQuery.setRetStart(0);
+        log.info("ESearch Query=[{}]", PubmedXmlQuery.redactApiKey(pubmedXmlQuery.buildESearchQuery()));
+
+        String postUrl;
+        if (pubmedXmlQuery.getApiKey() != null && !pubmedXmlQuery.getApiKey().isEmpty()) {
+            postUrl = PubmedXmlQuery.ESEARCH_BASE_URL + "?api_key=" + pubmedXmlQuery.getApiKey();
+        } else {
+            postUrl = PubmedXmlQuery.ESEARCH_BASE_URL;
+        }
+
         PubmedESearchResult eSearchResult = new PubmedESearchResult();
-        //InputStream esearchStream = new URL(fullUrl).openStream();
 
-        HttpClient httpClient = HttpClients.createDefault();
-        HttpPost httppost = new HttpPost(fullUrl);
+        HttpPost httppost = new HttpPost(postUrl);
         // Request parameters and other properties.
         List<NameValuePair> params = new ArrayList<>();
         params.add(new BasicNameValuePair("db", pubmedXmlQuery.getDb()));
@@ -200,52 +247,131 @@ public class PubMedArticleRetrievalService {
         params.add(new BasicNameValuePair("retstart", String.valueOf(pubmedXmlQuery.getRetStart())));
         httppost.setEntity(new UrlEncodedFormEntity(params));
         httppost.setHeader("Content-Type", "application/x-www-form-urlencoded");
-        httppost.getParams().setParameter(ClientPNames.COOKIE_POLICY, "standard");
         httppost.setHeader("cache-control", "no-cache");
-        
-        //Execute and get the response.
-        HttpResponse response = httpClient.execute(httppost);
-        
+
+        String responseString = executeReadingBody(httppost, term);
+
+        if (responseString == null || responseString.trim().isEmpty()
+                || !responseString.trim().startsWith("{")
+                || !objectMapper.readTree(responseString).has("esearchresult")) {
+            log.error("Unexpected response (not JSON), possibly an HTML error page.");
+            return eSearchResult;
+        }
+
+        JsonNode json = objectMapper.readTree(responseString).get("esearchresult");
+        if (json == null) {
+            return eSearchResult;
+        }
+
+        // Extract the "querytranslation" field and apply query-drop detection.
+        String queryTranslation = json.path("querytranslation").asText();
+        if (isValidAuthorString(queryTranslation)) {
+            log.info("Entered into process firstNameInitial strategy query");
+            // Split the string by [Author] and process each part.
+            List<String> segments = Arrays.stream(queryTranslation.split("\\[Author\\]"))
+                    .map(String::trim)
+                    .map(part -> part.replaceAll("\\b(AND|OR)\\b", ""))
+                    .map(part -> part.replaceAll("\\s", ""))
+                    .filter(part -> !part.isEmpty())
+                    .collect(Collectors.toList());
+
+            boolean isValidSegmentFound = false;
+            for (String part : segments) {
+                if (part.length() > 2) {
+                    isValidSegmentFound = true;
+                    break;
+                }
+            }
+
+            if (!isValidSegmentFound) {
+                log.error("No First Name initial found with more than 2 letters. Hence ignoring the records returned from PubMed for query=[{}].", term);
+                eSearchResult.setCount(0);
+                return eSearchResult;
+            }
+        }
+
+        eSearchResult = objectMapper.treeToValue(json, PubmedESearchResult.class);
+        log.info("esearchResults Count :" + eSearchResult.getCount());
+        return eSearchResult;
+    }
+
+    /**
+     * Executes the ESearch POST and returns the response body. When the NCBI rate-limit quota is
+     * exhausted (X-RateLimit-Remaining == 0) and a Retry-After header is present, sleeps for the
+     * advertised interval and replays the request once, returning the replayed response body.
+     * Response entities are always closed via try-with-resources.
+     */
+    private String executeReadingBody(HttpPost httppost, String query) throws IOException {
+        try (CloseableHttpResponse response = pubMedHttpClient.execute(httppost)) {
+            if (shouldRetryAfterRateLimit(response, query)) {
+                try (CloseableHttpResponse retryResponse = pubMedHttpClient.execute(httppost)) {
+                    return readBody(retryResponse);
+                }
+            }
+            return readBody(response);
+        }
+    }
+
+    private static String readBody(CloseableHttpResponse response) throws IOException {
+        HttpEntity entity = response.getEntity();
+        if (entity == null) {
+            return null;
+        }
+        StringWriter writer = new StringWriter();
+        try (InputStream esearchStream = entity.getContent()) {
+            IOUtils.copy(esearchStream, writer, "UTF-8");
+        }
+        return writer.toString();
+    }
+
+    /**
+     * Inspects the NCBI rate-limit response headers. Returns {@code true} (after sleeping for the
+     * advertised Retry-After interval) when the remaining quota is exhausted and the caller should
+     * replay the request. Header access is fully null/length guarded because NCBI omits these
+     * headers on error pages.
+     */
+    private boolean shouldRetryAfterRateLimit(CloseableHttpResponse response, String query) {
         Header[] headerRateLimitRemaining = response.getHeaders("X-RateLimit-Remaining");
         Header[] headerRateLimit = response.getHeaders("X-RateLimit-Limit");
         Header[] headerRetryAfter = response.getHeaders("Retry-After");
-        
-        log.info("Query : " + query  + " " + headerRateLimit[0].toString() + " " + headerRateLimitRemaining[0].toString());
-        
-        if(headerRateLimitRemaining != null && headerRateLimitRemaining.length > 0 && headerRateLimitRemaining[0] != null && Integer.parseInt(headerRateLimitRemaining[0].getValue()) == 0) {
-        	if(headerRetryAfter != null && headerRetryAfter.length > 0 && headerRetryAfter[0] != null) {
-        		log.info("Query : " + query  + " " + headerRetryAfter[0].toString());
-        		try {
-        			Thread.sleep(Long.parseLong(headerRetryAfter[0].getValue()) * 1000L);
-        		} catch (InterruptedException e) {
-        			log.error("InterruptedException", e);
-        		}
-        		response = httpClient.execute(httppost);
-        	}
-        }
-        
-		/*
-		 * Header[] headers = response.getAllHeaders(); for (Header header : headers) {
-		 * if(header.getName().equalsIgnoreCase("X-RateLimit-Limit") ||
-		 * header.getName().equalsIgnoreCase("X-RateLimit-Remaining") ||
-		 * header.getName().equalsIgnoreCase("Retry-After")) { log.info("Key : " +
-		 * header.getName() + " ,Value : " + header.getValue()); } }
-		 */
 
-        HttpEntity entity = response.getEntity();
-
-        if (entity != null) {
-            InputStream esearchStream = entity.getContent();
-			/*
-			 * StringWriter writer = new StringWriter(); IOUtils.copy(esearchStream, writer,
-			 * "UTF-8"); log.info(writer.toString());
-			 */
-            //SAXParserFactory.newInstance().newSAXParser().parse(esearchStream, pubmedESearchHandler);
-			JsonNode json = objectMapper.readTree(esearchStream).get("esearchresult");
-			if(json != null) {
-				eSearchResult = objectMapper.treeToValue(json, PubmedESearchResult.class);
-			}
+        if (headerRateLimit != null && headerRateLimit.length > 0 && headerRateLimit[0] != null
+                && headerRateLimitRemaining != null && headerRateLimitRemaining.length > 0 && headerRateLimitRemaining[0] != null) {
+            log.info("Query : " + query + " " + headerRateLimit[0].toString() + " " + headerRateLimitRemaining[0].toString());
         }
-        return eSearchResult;
+
+        if (headerRateLimitRemaining != null && headerRateLimitRemaining.length > 0 && headerRateLimitRemaining[0] != null
+                && Integer.parseInt(headerRateLimitRemaining[0].getValue()) == 0) {
+            if (headerRetryAfter != null && headerRetryAfter.length > 0 && headerRetryAfter[0] != null) {
+                log.info("Query : " + query + " " + headerRetryAfter[0].toString());
+                try {
+                    Thread.sleep(Long.parseLong(headerRetryAfter[0].getValue()) * 1000L);
+                } catch (InterruptedException e) {
+                    log.error("InterruptedException", e);
+                    Thread.currentThread().interrupt();
+                }
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean isValidAuthorString(String input) {
+        // Regular expression to match anything inside square brackets.
+        Pattern pattern = Pattern.compile("\\[(.*?)\\]");
+        Matcher matcher = pattern.matcher(input);
+        boolean containsAuthor = false;
+
+        while (matcher.find()) {
+            String matchedContent = matcher.group(1).trim(); // Get the content inside [].
+            // Check if the content is neither empty nor anything other than "Author".
+            if (!"Author".equals(matchedContent) && !"All Fields".equals(matchedContent)) {
+                return false; // Found something invalid inside [].
+            }
+            containsAuthor = true; // We found [Author].
+        }
+
+        // Return true if at least one [Author] exists, and no other value inside [].
+        return containsAuthor;
     }
 }

--- a/src/main/java/reciter/pubmed/xmlparser/PubmedEFetchHandler.java
+++ b/src/main/java/reciter/pubmed/xmlparser/PubmedEFetchHandler.java
@@ -19,6 +19,7 @@
 package reciter.pubmed.xmlparser;
 
 import java.nio.charset.Charset;
+import java.time.DateTimeException;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoField;
 import java.time.temporal.TemporalAccessor;
@@ -59,11 +60,14 @@ import reciter.model.pubmed.PubMedArticle;
 import reciter.model.pubmed.PubMedData;
 import reciter.model.pubmed.PubMedPubDate;
 
+import lombok.extern.slf4j.Slf4j;
+
 /**
  * A SAX handler that parses PubMed XML content.
  *
  * @author jil3004
  */
+@Slf4j
 public class PubmedEFetchHandler extends DefaultHandler {
 
     private boolean bPubmedArticleSet;
@@ -110,7 +114,6 @@ public class PubmedEFetchHandler extends DefaultHandler {
     private boolean bAuthorInitials;
     private boolean bAffiliationInfo;
     private boolean bAffiliation;
-    private boolean bAuthorEqualContrib;    
     private boolean bOrcid;
     private boolean bPublicationTypeList;
     private boolean bPublicationType;
@@ -158,7 +161,6 @@ public class PubmedEFetchHandler extends DefaultHandler {
     private boolean bReference;
     private boolean bReferenceArticleIdList;
     private boolean bReferenceArticleId;
-    private boolean bEqualContrib;
     private boolean bCoiStatement;
 
     private List<PubMedArticle> pubmedArticles;
@@ -209,7 +211,7 @@ public class PubmedEFetchHandler extends DefaultHandler {
     }
 
     private boolean isOrcid(Attributes attributes) {
-        return attributes.getValue("Source").equalsIgnoreCase("ORCID");
+        return "ORCID".equalsIgnoreCase(attributes.getValue("Source"));
     }
     private String getEqualContrib(Attributes attributes)
     {
@@ -245,15 +247,21 @@ public class PubmedEFetchHandler extends DefaultHandler {
             
             if(matcher.find()) {
                 month = matcher.group();
-                DateTimeFormatter parser = DateTimeFormatter.ofPattern("MMM").withLocale(Locale.ENGLISH);
-                TemporalAccessor accessor = parser.parse(month);
-                int monthNumber = accessor.get(ChronoField.MONTH_OF_YEAR);
-                if(monthNumber != 0 && monthNumber < 10) {
-                    month = "0" + String.valueOf(monthNumber);
-                } else {
-                    month = String.valueOf(monthNumber);
+                try {
+                    DateTimeFormatter parser = DateTimeFormatter.ofPattern("MMM").withLocale(Locale.ENGLISH);
+                    TemporalAccessor accessor = parser.parse(month);
+                    int monthNumber = accessor.get(ChronoField.MONTH_OF_YEAR);
+                    if(monthNumber != 0 && monthNumber < 10) {
+                        month = "0" + String.valueOf(monthNumber);
+                    } else {
+                        month = String.valueOf(monthNumber);
+                    }
+                } catch (DateTimeException e) {
+                    // Not a valid English month abbreviation (e.g. a season token). Fall back to "01"
+                    // rather than letting the unchecked exception abort the entire EFetch batch.
+                    log.warn("Unable to parse month token '{}' in MedlineDate '{}'; defaulting to 01", month, medlineDate);
+                    month = "01";
                 }
-                
             }
             if(month == null) {
                 month = "01";
@@ -307,7 +315,7 @@ public class PubmedEFetchHandler extends DefaultHandler {
                 bArticleTitle = true;
             }
 
-            if (qName.equalsIgnoreCase("ELocationID") && attributes.getValue("EIdType").equalsIgnoreCase("doi")) {
+            if (qName.equalsIgnoreCase("ELocationID") && "doi".equalsIgnoreCase(attributes.getValue("EIdType"))) {
                 pubmedArticle.getMedlinecitation().getArticle().setElocationid(MedlineCitationArticleELocationID.builder().build());
                 bELocationID = true;
             }
@@ -398,6 +406,10 @@ public class PubmedEFetchHandler extends DefaultHandler {
             }
             if (qName.equalsIgnoreCase("Author")) {
                 MedlineCitationArticleAuthor author = MedlineCitationArticleAuthor.builder().build();
+                // Set equalContrib on this single author object when the attribute is present.
+                if (getEqualContrib(attributes) != null) {
+                    author.setEqualContrib(getEqualContrib(attributes));
+                }
                 pubmedArticle.getMedlinecitation().getArticle().getAuthorlist().add(author); // add author to author list.
                 bAuthor = true;
             }
@@ -412,15 +424,6 @@ public class PubmedEFetchHandler extends DefaultHandler {
             }
             if (qName.equalsIgnoreCase("Affiliation")) {
                 bAffiliation = true;
-            }
-            // Check if author has EqualContrib attribute
-
-						if (qName.equalsIgnoreCase("Author") && bAuthorList && getEqualContrib(attributes)!=null)
-            			{
-							  MedlineCitationArticleAuthor author = MedlineCitationArticleAuthor.builder().build();
-							  author.setEqualContrib(getEqualContrib(attributes));
-            		pubmedArticle.getMedlinecitation().getArticle().getAuthorlist().add(author); // add author to author list.
-			          bEqualContrib = true;
             }
             if(qName.equalsIgnoreCase("Identifier") && bAuthorList && isOrcid(attributes)) {
                 bOrcid = true;
@@ -557,7 +560,7 @@ public class PubmedEFetchHandler extends DefaultHandler {
         // Get DOI from <ArticleId IdType="doi">DOI here</ArticleId> in cases where ELocationID is missing. This is typically for older publications
         // But only extract DOI if we are NOT inside a Reference tag
 
-            if (qName.equalsIgnoreCase("ArticleId") && !bReference && !bReferenceList && attributes.getValue("IdType").equalsIgnoreCase("doi") && bELocationID != true) {
+            if (qName.equalsIgnoreCase("ArticleId") && !bReference && !bReferenceList && "doi".equalsIgnoreCase(attributes.getValue("IdType")) && bELocationID != true) {
                 pubmedArticle.getMedlinecitation().getArticle().setElocationid(MedlineCitationArticleELocationID.builder().build());
                 bELocationID = true;
             }
@@ -730,13 +733,6 @@ public class PubmedEFetchHandler extends DefaultHandler {
                 bAuthorInitials = false;
             }
 
-            // Author equal contribution
-            if (bAuthorEqualContrib) {
-              int lastInsertedIndex = pubmedArticle.getMedlinecitation().getArticle().getAuthorlist().size() - 1;
-              pubmedArticle.getMedlinecitation().getArticle().getAuthorlist().get(lastInsertedIndex).setEqualContrib("Y");
-              bAuthorEqualContrib = false; 
-            }
-
             // Author affiliations.
             if (bAffiliation) {
 
@@ -762,15 +758,6 @@ public class PubmedEFetchHandler extends DefaultHandler {
                 }
                 pubmedArticle.getMedlinecitation().getArticle().getAuthorlist().get(lastInsertedIndex).setAffiliation(affiliations);
                 bAffiliation = false;
-            }
-            //Author EqualContrib flag
-            if(qName.equalsIgnoreCase("Author") && bAuthorList && bEqualContrib)
-            {
-            	
-            	int lastInsertedIndex = pubmedArticle.getMedlinecitation().getArticle().getAuthorlist().size() - 1;
-            	String equalContrib = pubmedArticle.getMedlinecitation().getArticle().getAuthorlist().get(lastInsertedIndex).getEqualContrib();
-            	pubmedArticle.getMedlinecitation().getArticle().getAuthorlist().get(lastInsertedIndex).setEqualContrib(equalContrib);
-                bEqualContrib = false;
             }
             
             // Author ORCID identifier
@@ -835,13 +822,19 @@ public class PubmedEFetchHandler extends DefaultHandler {
             if (bPubDate && bPubDateMonth) {
                 String pubDateMonth = chars.toString();
                 if(pubDateMonth.trim().length() == 3) {
-                    DateTimeFormatter parser = DateTimeFormatter.ofPattern("MMM").withLocale(Locale.ENGLISH);
-                    TemporalAccessor accessor = parser.parse(pubDateMonth);
-                    int monthNumber = accessor.get(ChronoField.MONTH_OF_YEAR);
-                    if(monthNumber != 0 && monthNumber < 10 ) {
-                        pubDateMonth = "0" + String.valueOf(monthNumber);
-                    } else {
-                        pubDateMonth = String.valueOf(monthNumber);
+                    try {
+                        DateTimeFormatter parser = DateTimeFormatter.ofPattern("MMM").withLocale(Locale.ENGLISH);
+                        TemporalAccessor accessor = parser.parse(pubDateMonth);
+                        int monthNumber = accessor.get(ChronoField.MONTH_OF_YEAR);
+                        if(monthNumber != 0 && monthNumber < 10 ) {
+                            pubDateMonth = "0" + String.valueOf(monthNumber);
+                        } else {
+                            pubDateMonth = String.valueOf(monthNumber);
+                        }
+                    } catch (DateTimeException e) {
+                        // 3-char value that isn't a valid English month abbreviation (e.g. a season token).
+                        // Keep the raw value instead of letting the unchecked exception abort the entire EFetch batch.
+                        log.warn("Unable to parse PubDate month token '{}'; keeping raw value", pubDateMonth);
                     }
                 }
                 pubmedArticle.getMedlinecitation().getArticle().getJournal().getJournalissue().getPubdate().setMonth(pubDateMonth);
@@ -1160,11 +1153,6 @@ public class PubmedEFetchHandler extends DefaultHandler {
             chars.append(ch, start, length);
         }
 
-        // Added handling for EqualContrib
-        if (bAuthorEqualContrib) {
-          chars.append(ch, start, length);
-        }              
-
         if (bELocationID) {
             chars.append(ch, start, length);
         }
@@ -1258,9 +1246,7 @@ public class PubmedEFetchHandler extends DefaultHandler {
         }
 
         if (bGrant && bGrantCountry) {
-            if (chars.length() == 0) {
-                chars.append(ch, start, length);
-            }
+            chars.append(ch, start, length);
         }
         
         if(bPublicationTypeList && bPublicationType) {

--- a/src/main/java/reciter/pubmed/xmlparser/PubmedEFetchHandler.java
+++ b/src/main/java/reciter/pubmed/xmlparser/PubmedEFetchHandler.java
@@ -295,6 +295,9 @@ public class PubmedEFetchHandler extends DefaultHandler {
         if (qName.equalsIgnoreCase("PubmedArticle")) {
             pubmedArticle = PubMedArticle.builder().build(); // create a new PubmedArticle.
         }
+        if (qName.equalsIgnoreCase("PubmedBookArticle")) {
+            pubmedArticle = null; // Prevent book article fields from corrupting previous article
+        }
         //This check was introduced for articles which are of book type returning  <PubmedBookArticle> tag
         if (pubmedArticle != null) {
             if (qName.equalsIgnoreCase("MedlineCitation")) {
@@ -427,11 +430,6 @@ public class PubmedEFetchHandler extends DefaultHandler {
             }
             if(qName.equalsIgnoreCase("Identifier") && bAuthorList && isOrcid(attributes)) {
                 bOrcid = true;
-            }
-            if (qName.equalsIgnoreCase("AuthorList") &&
-                    pubmedArticle != null) {
-                pubmedArticle.getMedlinecitation().getArticle().setAuthorlist(new ArrayList<>()); // set the PubmedArticle's MedlineCitation's MedlineCitationArticle's title.
-                bAuthorList = true;
             }
             if (qName.equalsIgnoreCase("Abstract") &&
                     pubmedArticle != null) {

--- a/src/main/java/reciter/pubmed/xmlparser/PubmedEFetchHandler.java
+++ b/src/main/java/reciter/pubmed/xmlparser/PubmedEFetchHandler.java
@@ -287,7 +287,12 @@ public class PubmedEFetchHandler extends DefaultHandler {
     @Override
     public void startElement(String uri, String localName, String qName, Attributes attributes) throws SAXException {
 
-        chars.setLength(0);
+        // Fix #14: Only clear accumulated text when not inside ArticleTitle or AbstractText.
+        // PubMed XML can contain inline markup (MathML, <i>, <b>, <sup>, <sub>) inside
+        // these elements. Clearing chars on nested elements would discard the preceding text.
+        if (!(bArticleTitle || (bAbstractText && bAbstract))) {
+            chars.setLength(0);
+        }
 
         if (qName.equalsIgnoreCase("PubmedArticleSet")) {
             pubmedArticles = new ArrayList<>(); // create a new list of PubmedArticle.

--- a/src/main/java/reciter/pubmed/xmlparser/PubmedESearchHandler.java
+++ b/src/main/java/reciter/pubmed/xmlparser/PubmedESearchHandler.java
@@ -1,33 +1,13 @@
 package reciter.pubmed.xmlparser;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.ArrayList;
-import java.util.List;
-
-import javax.xml.parsers.ParserConfigurationException;
-
 import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import org.apache.http.Header;
-import org.apache.http.HttpEntity;
-import org.apache.http.HttpResponse;
-import org.apache.http.NameValuePair;
-import org.apache.http.client.HttpClient;
-import org.apache.http.client.entity.UrlEncodedFormEntity;
-import org.apache.http.client.methods.HttpPost;
-import org.apache.http.client.params.ClientPNames;
-import org.apache.http.impl.client.HttpClients;
-import org.apache.http.message.BasicNameValuePair;
 import org.xml.sax.Attributes;
 import org.xml.sax.SAXException;
 import org.xml.sax.helpers.DefaultHandler;
 
 import lombok.extern.slf4j.Slf4j;
-import reciter.pubmed.model.PubmedESearchResult;
-import reciter.pubmed.querybuilder.PubmedXmlQuery;
 
 /**
  * A SAX handler for parsing the ESearch query from PubMed.
@@ -42,107 +22,10 @@ public class PubmedESearchHandler extends DefaultHandler {
     private boolean bWebEnv;
     private boolean bCount;
     private int numCountEncounteredSoFar = 0;
-    
+
     private static ObjectMapper objectMapper = new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 
     private StringBuilder chars = new StringBuilder();
-
-    /**
-     * Sends a query to the NCBI web site to retrieve the webEnv.
-     *
-     * @param eSearchUrl example query: http://www.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi?db=pubmed&retmax=1&usehistory=y&term=Kukafka%20R[au].
-     * @return WebEnvHandler that contains the WebEnv data.
-     * @throws ParserConfigurationException
-     * @throws SAXException
-     * @throws IOException
-     */
-    public static PubmedESearchResult executeESearchQuery(String eSearchUrl) {
-        PubmedESearchHandler webEnvHandler = new PubmedESearchHandler();
-        PubmedESearchResult eSearchResult = new PubmedESearchResult();
-        /*InputStream inputStream = null;
-        try {
-            inputStream = new URL(eSearchUrl).openStream();
-        } catch (IOException e) {
-            log.error("Error in executeESearchQuery", e);
-        }
-        try {
-            SAXParserFactory.newInstance().newSAXParser().parse(inputStream, webEnvHandler);
-        } catch (Exception e) {
-            log.error("Error in executeESearchQuery. url=[" + eSearchUrl + "]", e);
-        }*/
-        PubmedXmlQuery pubmedXmlQuery = new PubmedXmlQuery(eSearchUrl);
-        pubmedXmlQuery.setRetMax(1);
-        String fullUrl = pubmedXmlQuery.buildESearchQuery(); // build eSearch query.
-        log.info("ESearch Query=[" + fullUrl + "]");
-        if(pubmedXmlQuery.getApiKey() != null &&
-       		  !pubmedXmlQuery.getApiKey().isEmpty()) {
-        	fullUrl = PubmedXmlQuery.ESEARCH_BASE_URL + "?api_key=" + pubmedXmlQuery.getApiKey();
-	      } else {
-	      	fullUrl = PubmedXmlQuery.ESEARCH_BASE_URL;
-	      }
-
-        try {
-            HttpClient httpClient = HttpClients.createDefault();
-            HttpPost httppost = new HttpPost(fullUrl);
-            //httppost.setHeader(HttpHeaders.ACCEPT, "application/xml");
-            // Request parameters and other properties.
-            List<NameValuePair> params = new ArrayList<NameValuePair>();
-            params.add(new BasicNameValuePair("db", pubmedXmlQuery.getDb()));
-            params.add(new BasicNameValuePair("retmax", String.valueOf(pubmedXmlQuery.getRetMax())));
-            params.add(new BasicNameValuePair("usehistory", pubmedXmlQuery.getUseHistory()));
-            params.add(new BasicNameValuePair("term", java.net.URLDecoder.decode(pubmedXmlQuery.getTerm(), "UTF-8")));
-            params.add(new BasicNameValuePair("retmode", pubmedXmlQuery.getRetMode()));
-            params.add(new BasicNameValuePair("retstart", String.valueOf(pubmedXmlQuery.getRetStart())));
-            httppost.setEntity(new UrlEncodedFormEntity(params));
-            httppost.setHeader("Content-Type", "application/x-www-form-urlencoded");
-            httppost.getParams().setParameter(ClientPNames.COOKIE_POLICY, "standard");
-            //Execute and get the response.
-            
-            HttpResponse response = httpClient.execute(httppost);
-            Header[] headerRateLimitRemaining = response.getHeaders("X-RateLimit-Remaining");
-            Header[] headerRetryAfter = response.getHeaders("Retry-After");
-            
-            if(headerRateLimitRemaining != null && headerRateLimitRemaining.length > 0 && headerRateLimitRemaining[0] != null && Integer.parseInt(headerRateLimitRemaining[0].getValue()) == 0) {
-            	if(headerRetryAfter != null && headerRetryAfter.length > 0 && headerRetryAfter[0] != null) {
-            		try {
-            			Thread.sleep(Long.parseLong(headerRetryAfter[0].getValue()) * 1000L);
-            		} catch (InterruptedException e) {
-            			log.error("InterruptedException", e);
-            		}
-            		response = httpClient.execute(httppost);
-            	}
-            }
-            
-			/*
-			 * Header[] headers = response.getAllHeaders(); for (Header header : headers) {
-			 * if(header.getName().equalsIgnoreCase("X-RateLimit-Limit") ||
-			 * header.getName().equalsIgnoreCase("X-RateLimit-Remaining") ||
-			 * header.getName().equalsIgnoreCase("Retry-After")) { log.info("Key : " +
-			 * header.getName() + " ,Value : " + header.getValue()); } }
-			 */
-
-            HttpEntity entity = response.getEntity();
-
-            if (entity != null) {
-                InputStream esearchStream = entity.getContent();
-				/*
-				 * StringWriter writer = new StringWriter(); IOUtils.copy(esearchStream, writer,
-				 * "UTF-8"); log.info(writer.toString());
-				 */
-                //String sanitizedStream = IOUtils.toString(esearchStream).trim().replaceFirst("^([\\W]+)<","<");
-                //log.info(sanitizedStream);
-                //SAXParserFactory.newInstance().newSAXParser().parse(esearchStream, webEnvHandler);
-    			JsonNode json = objectMapper.readTree(esearchStream).get("esearchresult");
-    			if(json != null) {
-    				eSearchResult = objectMapper.treeToValue(json, PubmedESearchResult.class);
-    			}
-            }
-        } catch (IOException e) {
-            log.error("Error parsing XML file for query=[" + eSearchUrl + "], full url=[" + fullUrl + "]", e);
-        }
-
-        return eSearchResult;
-    }
 
     @Override
     public void startElement(String uri, String localName, String qName, Attributes attributes) throws SAXException {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,2 +1,6 @@
-logging.file.name=logs/reciter-pubmed-retrieval-tool.log
 server.port=5000
+
+# Logging goes to stdout/console only (see logback-spring.xml) so it is collected
+# into CloudWatch from the container's stdout on EKS (Fluent Bit / Container Insights).
+# File logging is intentionally NOT configured: an in-container log file is ephemeral
+# and is never shipped to CloudWatch (and is lost on pod restart).

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,2 +1,2 @@
-logging.file=logs/reciter-pubmed-retrieval-tool.log
+logging.file.name=logs/reciter-pubmed-retrieval-tool.log
 server.port=5000

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <!--
+        Application logs are written to stdout/console only, so they are collected
+        into CloudWatch from the container's stdout on EKS (Fluent Bit / Container
+        Insights). Do NOT add a file appender: an in-container log file is ephemeral,
+        is not shipped to CloudWatch, and is lost on pod restart.
+
+        The verbose full PubMed response body is no longer logged (see the controller);
+        raise a specific logger to DEBUG at runtime if deeper diagnostics are needed,
+        e.g. LOGGING_LEVEL_RECITER=DEBUG.
+    -->
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="reciter" level="INFO"/>
+
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+    </root>
+</configuration>

--- a/src/test/java/reciter/pubmed/xmlparser/PubmedEFetchHandlerTest.java
+++ b/src/test/java/reciter/pubmed/xmlparser/PubmedEFetchHandlerTest.java
@@ -69,6 +69,36 @@ public class PubmedEFetchHandlerTest {
         assertNull(pubMedArticle.getMedlinecitation().getArticle().getAuthorlist().get(1).getOrcid());
     }
 
+    /**
+     * Equal-contributor authors (<Author EqualContrib="Y">) must be added exactly once.
+     * Previously a second phantom (empty) author was added per equal-contributor tag, corrupting
+     * the author list size, positions, and names. Verify de-duplication and that equalContrib is
+     * set on the single, correctly-populated author object.
+     */
+    @Test
+    public void testEqualContribDeduplication() throws Exception {
+        inputSource = new InputSource(this.getClass().getResourceAsStream("equalcontrib.xml"));
+        pubMedUriParserCallable = new PubMedUriParserCallable(xmlHandler, saxParser, inputSource);
+        List<PubMedArticle> pubMedArticles = pubMedUriParserCallable.call();
+        PubMedArticle pubMedArticle = pubMedArticles.get(0);
+
+        // Exactly three authors -- no phantom/empty author injected for the equal-contributor tags.
+        assertEquals(3, pubMedArticle.getMedlinecitation().getArticle().getAuthorlist().size());
+
+        // First equal-contributor author: name fields populated on the same object that carries equalContrib.
+        assertEquals("Smith", pubMedArticle.getMedlinecitation().getArticle().getAuthorlist().get(0).getLastname());
+        assertEquals("Alice B", pubMedArticle.getMedlinecitation().getArticle().getAuthorlist().get(0).getForename());
+        assertEquals("Y", pubMedArticle.getMedlinecitation().getArticle().getAuthorlist().get(0).getEqualContrib());
+
+        // Second equal-contributor author.
+        assertEquals("Jones", pubMedArticle.getMedlinecitation().getArticle().getAuthorlist().get(1).getLastname());
+        assertEquals("Y", pubMedArticle.getMedlinecitation().getArticle().getAuthorlist().get(1).getEqualContrib());
+
+        // Non equal-contributor author: name populated, equalContrib left null.
+        assertEquals("Nguyen", pubMedArticle.getMedlinecitation().getArticle().getAuthorlist().get(2).getLastname());
+        assertNull(pubMedArticle.getMedlinecitation().getArticle().getAuthorlist().get(2).getEqualContrib());
+    }
+
     @Test
     public void testReferenceList() throws Exception {
         inputSource = new InputSource(this.getClass().getResourceAsStream("32025781.xml"));

--- a/src/test/resources/reciter/pubmed/xmlparser/equalcontrib.xml
+++ b/src/test/resources/reciter/pubmed/xmlparser/equalcontrib.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" ?>
+<!DOCTYPE PubmedArticleSet PUBLIC "-//NLM//DTD PubMedArticle, 1st January 2019//EN" "https://dtd.nlm.nih.gov/ncbi/pubmed/out/pubmed_190101.dtd">
+<PubmedArticleSet>
+    <PubmedArticle>
+        <MedlineCitation Status="MEDLINE" Owner="NLM">
+            <PMID Version="1">99999999</PMID>
+            <Article PubModel="Print">
+                <ArticleTitle>Equal contributor de-duplication test article.</ArticleTitle>
+                <AuthorList CompleteYN="Y">
+                    <Author ValidYN="Y" EqualContrib="Y">
+                        <LastName>Smith</LastName>
+                        <ForeName>Alice B</ForeName>
+                        <Initials>AB</Initials>
+                    </Author>
+                    <Author ValidYN="Y" EqualContrib="Y">
+                        <LastName>Jones</LastName>
+                        <ForeName>Carlos D</ForeName>
+                        <Initials>CD</Initials>
+                    </Author>
+                    <Author ValidYN="Y">
+                        <LastName>Nguyen</LastName>
+                        <ForeName>Emma F</ForeName>
+                        <Initials>EF</Initials>
+                    </Author>
+                </AuthorList>
+            </Article>
+        </MedlineCitation>
+    </PubmedArticle>
+</PubmedArticleSet>


### PR DESCRIPTION
## Summary

Two non-breaking controller improvements:

### #118 (exception-handler portion only)
Adds `reciter.controller.GlobalExceptionHandler`, a `@RestControllerAdvice` that returns clean JSON `{error, message}` bodies and never leaks stack traces to clients (stack traces are logged server-side only).

- The threshold-exceeded case — `PubMedArticleRetrievalService.retrieve` throws `IOException("Number of PubMed Articles retrieved N exceeded the threshold level 2000")` — is mapped to **502 Bad Gateway** with `{"error":"threshold_exceeded","message":"..."}`.
- Other upstream `IOException`s map to **502** with `{"error":"upstream_error","message":"..."}`.
- All remaining uncaught exceptions map to a generic **500** with `{"error":"internal_error","message":"..."}` and no internal detail.

### #121
In `PubMedRetrievalToolController.retrieve(query, fields)`:
- When `fields` is null/empty, the per-article Squiggly `stringify` -> `readValue` round-trip is **skipped entirely**; the retrieved articles are returned directly (copied into a new list).
- When a `fields` filter is present, the filtering behavior is unchanged **except** that a per-item serialization failure now **skips** the element rather than inserting a `null` into the result list.

## Intentionally deferred (breaking — NOT in this PR)
Issue #118 also recommends returning the count endpoint inside a `{count, status}` DTO (and standardizing all endpoints on `ResponseEntity`). That changes `getNumberOfPubMedArticles`'s return type from bare `int` to a DTO, which is a **breaking** change for existing callers and is tracked separately. No endpoint return type or signature is changed in this PR.

## Testing
All commands run with `JAVA_HOME=/opt/homebrew/opt/openjdk@11/...` (OpenJDK 11):

- `mvn -B -ntp clean package -DskipTests` → **BUILD SUCCESS**
- `mvn -B -ntp test -Dtest=PubmedEFetchHandlerTest,PubMedUriParserCallableTest -DfailIfNoTests=false` → **Tests run: 7, Failures: 0, Errors: 0, Skipped: 0** → BUILD SUCCESS

The live load test was not run.

Closes #118
Closes #121
