### PR TITLE
Promote #137 to production: global exception handler + skip redundant Squiggly round-trip (dev → master)

### DIFF
--- a/src/main/java/reciter/controller/GlobalExceptionHandler.java
+++ b/src/main/java/reciter/controller/GlobalExceptionHandler.java
@@ -1,0 +1,57 @@
+package reciter.controller;
+
+import java.io.IOException;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Global exception handler producing clean JSON error responses without leaking stack traces
+ * or internal exception detail to clients. Stack traces are logged server-side only.
+ *
+ * <p>The threshold-exceeded case (thrown as an {@link IOException} by
+ * {@code PubMedArticleRetrievalService.retrieve} when the matching article count exceeds the
+ * retrieval threshold) is mapped to {@code 502 Bad Gateway} with a small {@code {error, message}}
+ * body so callers can distinguish it from a generic failure. All other uncaught exceptions are
+ * mapped to a generic {@code 500 Internal Server Error} body with no internal detail.
+ */
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    /** Marker substring identifying the threshold-exceeded IOException message. */
+    private static final String THRESHOLD_EXCEEDED_MARKER = "exceeded the threshold level";
+
+    @ExceptionHandler(IOException.class)
+    public ResponseEntity<Map<String, Object>> handleIOException(IOException ex) {
+        String message = ex.getMessage();
+        if (message != null && message.contains(THRESHOLD_EXCEEDED_MARKER)) {
+            log.warn("PubMed retrieval threshold exceeded: {}", message);
+            return errorResponse(HttpStatus.BAD_GATEWAY, "threshold_exceeded",
+                    "The query matched too many PubMed articles to retrieve. Please refine the query.");
+        }
+        log.error("Upstream PubMed retrieval error.", ex);
+        return errorResponse(HttpStatus.BAD_GATEWAY, "upstream_error",
+                "Unable to retrieve results from PubMed at this time.");
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<Map<String, Object>> handleException(Exception ex) {
+        log.error("Unhandled exception while processing request.", ex);
+        return errorResponse(HttpStatus.INTERNAL_SERVER_ERROR, "internal_error",
+                "An unexpected error occurred while processing the request.");
+    }
+
+    private static ResponseEntity<Map<String, Object>> errorResponse(HttpStatus status, String error, String message) {
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("error", error);
+        body.put("message", message);
+        return ResponseEntity.status(status).body(body);
+    }
+}

--- a/src/main/java/reciter/controller/PubMedRetrievalToolController.java
+++ b/src/main/java/reciter/controller/PubMedRetrievalToolController.java
@@ -82,9 +82,17 @@ public class PubMedRetrievalToolController {
     private List<PubMedArticle> retrieve(String query, String fields) throws IOException {
         query = URLEncoder.encode(query, "UTF-8");
         log.info("Retrieving with query=[" + query + "]");
-        if (fields != null && !fields.isEmpty()) {
-            fields = fields.toLowerCase();
+
+        List<PubMedArticle> pubMedArticles = pubMedArticleRetrievalService.retrieve(query);
+        log.info("retrieved " + pubMedArticles.size() + " PubMed articles using query=[" + query + "]");
+
+        // No field selection requested: return the retrieved articles directly and skip the
+        // per-article Squiggly stringify -> readValue round-trip entirely.
+        if (fields == null || fields.isEmpty()) {
+            return new ArrayList<>(pubMedArticles);
         }
+
+        fields = fields.toLowerCase();
         ObjectMapper objectMapper = Squiggly
                 .init(new ObjectMapper(), fields)
                 .configure(MapperFeature.ACCEPT_CASE_INSENSITIVE_PROPERTIES, true)
@@ -92,18 +100,15 @@ public class PubMedRetrievalToolController {
                 .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
 
         List<PubMedArticle> result = new ArrayList<>();
-        List<PubMedArticle> pubMedArticles = pubMedArticleRetrievalService.retrieve(query);
         pubMedArticles.forEach(elem -> {
             String partialObject = SquigglyUtils.stringify(objectMapper, elem);
-            PubMedArticle pubMedArticle = null;
             try {
-                pubMedArticle = objectMapper.readValue(partialObject, PubMedArticle.class);
+                // On a per-item serialization failure, skip the element rather than adding null.
+                result.add(objectMapper.readValue(partialObject, PubMedArticle.class));
             } catch (IOException e) {
                 log.error("Unable to read value from pmid=" + elem.getMedlinecitation().getMedlinecitationpmid().getPmid(), e);
             }
-            result.add(pubMedArticle);
         });
-        log.info("retrieved " + pubMedArticles.size() + " PubMed articles using query=[" + query + "]");
         return result;
     }
 }

--- a/src/main/java/reciter/pubmed/xmlparser/PubmedEFetchHandler.java
+++ b/src/main/java/reciter/pubmed/xmlparser/PubmedEFetchHandler.java
@@ -287,6 +287,9 @@ public class PubmedEFetchHandler extends DefaultHandler {
         if (qName.equalsIgnoreCase("PubmedArticle")) {
             pubmedArticle = PubMedArticle.builder().build(); // create a new PubmedArticle.
         }
+        if (qName.equalsIgnoreCase("PubmedBookArticle")) {
+            pubmedArticle = null; // Prevent book article fields from corrupting previous article
+        }
         //This check was introduced for articles which are of book type returning  <PubmedBookArticle> tag
         if (pubmedArticle != null) {
             if (qName.equalsIgnoreCase("MedlineCitation")) {
@@ -424,11 +427,6 @@ public class PubmedEFetchHandler extends DefaultHandler {
             }
             if(qName.equalsIgnoreCase("Identifier") && bAuthorList && isOrcid(attributes)) {
                 bOrcid = true;
-            }
-            if (qName.equalsIgnoreCase("AuthorList") &&
-                    pubmedArticle != null) {
-                pubmedArticle.getMedlinecitation().getArticle().setAuthorlist(new ArrayList<>()); // set the PubmedArticle's MedlineCitation's MedlineCitationArticle's title.
-                bAuthorList = true;
             }
             if (qName.equalsIgnoreCase("Abstract") &&
                     pubmedArticle != null) {


### PR DESCRIPTION
## Promote #137 to production (dev → master)

Brings the two non-breaking controller improvements from #137 (already merged to `dev`, CI-green) up to `master`.

### Changes (net diff: 2 files, +69/−7)
- **New** `reciter.controller.GlobalExceptionHandler` (`@RestControllerAdvice`): clean JSON `{error, message}` responses, no stack-trace leakage to clients.
  - Threshold-exceeded `IOException` → **502** `{"error":"threshold_exceeded"}`
  - Other upstream `IOException` → **502** `{"error":"upstream_error"}`
  - Uncaught → **500** `{"error":"internal_error"}` (no internal detail)
- **`PubMedRetrievalToolController.retrieve`**: skip the per-article Squiggly `stringify` → `readValue` round-trip when no `fields` filter is set; on per-item failure, skip the element instead of inserting a `null`.

Closes #118
Closes #121

### Notes
- Net diff is exactly the #137 change set. The commit list also shows the #105 book-article-parser commit, whose content already landed on `master` via #134, so it contributes **no net diff** here.
- The breaking structured-count DTO portion of #118 remains deferred to #130 (not in this PR).

### Testing
- #137 built green on `dev` (JDK 11, `mvn -B -ntp clean package`) and passed the parser unit tests prior to its merge into `dev`.
- CI (GitHub Actions, added in #133) runs on this PR.