### PR TITLE
Remove dead code in PubMed XML parsers: PubmedESearchHandler SAX machinery + EFetch commented blocks/unread ArticleId flags (#126)

### DIFF
--- a/src/main/java/reciter/pubmed/xmlparser/PubmedEFetchHandler.java
+++ b/src/main/java/reciter/pubmed/xmlparser/PubmedEFetchHandler.java
@@ -141,9 +141,6 @@ public class PubmedEFetchHandler extends DefaultHandler {
     private boolean bPublicationStatus;
     private boolean bArticleIdList;
     private boolean bArticleId;
-    private boolean bArticleIdPubMed;
-    private boolean bArticleIdPii;
-    private boolean bArticleIdDoi;
     private boolean bArticleIdPmc;
     private boolean bGrantList;
     private boolean bGrant;
@@ -590,12 +587,7 @@ public class PubmedEFetchHandler extends DefaultHandler {
             }
             
 
-            // not used.
-            //      if (qName.equalsIgnoreCase("RefSource") && bCommentsCorrections) {
-            //          bCommentsCorrectionsRefSource = true;
-            //      }
             if (qName.equalsIgnoreCase("PMID") && bCommentsCorrections) {
-                //          bCommentsCorrectionsPmidVersion = true;
                 bCommentsCorrectionsPmid = true;
             }
 
@@ -641,25 +633,14 @@ public class PubmedEFetchHandler extends DefaultHandler {
                 bArticleIdList = true;
             }
 
-            if (qName.equalsIgnoreCase("ArticleId") && !bReferenceArticleIdList && !bReferenceArticleId && !bReference) {  
+            if (qName.equalsIgnoreCase("ArticleId") && !bReferenceArticleIdList && !bReferenceArticleId && !bReference) {
                 bArticleId = true;
                 String idType = getArticleIdType(attributes);
-                if ("pubmed".equals(idType)) {
-                    bArticleIdPubMed = true;
-                } else if ("pii".equals(idType)) {
-                    bArticleIdPii = true;
-                } else if ("doi".equals(idType)) {
-                    bArticleIdDoi = true;
-                } else if ("pmc".equals(idType)) {
+                if ("pmc".equals(idType)) {
                     pubmedArticle.getPubmeddata().setArticleIdList(new ArticleIdList());
                     bArticleIdPmc = true;
                 }
             }
-            /*if(qName.equalsIgnoreCase("CoiStatement"))
-            {
-            	 String coiStatment = chars.toString();
-                 pubmedArticle.getMedlinecitation().setCoiStatement(coiStatment);
-            }*/
         }
     }
 
@@ -689,13 +670,7 @@ public class PubmedEFetchHandler extends DefaultHandler {
             
                 // Delete certain non-printable, hexadecimal characters
                 articleTitle = articleTitle.replaceAll("[\u2029\u0099\u2003]", "");
-            
-                // Output the encoding being used
-                // System.out.println("Encoding: " + Charset.defaultCharset().displayName());
-            
-                // Output the value of articleTitle
-                // System.out.println("Article Title: " + articleTitle);
-            
+
                 // Set the title of the article.
                 pubmedArticle.getMedlinecitation().getArticle().setArticletitle(articleTitle); 
                 bArticleTitle = false;
@@ -1127,21 +1102,11 @@ public class PubmedEFetchHandler extends DefaultHandler {
                 bReference = false;
             }
             if(qName.equalsIgnoreCase("CoiStatement") && bCoiStatement) {
-            	
+
             	  String coiStatement = chars.toString();
-                  pubmedArticle.getMedlinecitation().setCoiStatement(coiStatement); 
+                  pubmedArticle.getMedlinecitation().setCoiStatement(coiStatement);
                   bCoiStatement = false;
             }
-
-            /*if (qName.equalsIgnoreCase("ArticleIdList")) {
-                bArticleIdList = false;
-                bArticleId = false;
-                bArticleIdPubMed = false;
-                bArticleIdPii = false;
-                bArticleIdDoi = false;
-            }*/
-
-            
         }
     }
 
@@ -1302,10 +1267,5 @@ public class PubmedEFetchHandler extends DefaultHandler {
         if(bCoiStatement) {
         	chars.append(ch, start, length);
         }
-        	
-        
-        /*if (bPubmedData) {
-            chars.append(ch, start, length);
-        }*/
     }
 }

--- a/src/main/java/reciter/pubmed/xmlparser/PubmedESearchHandler.java
+++ b/src/main/java/reciter/pubmed/xmlparser/PubmedESearchHandler.java
@@ -1,16 +1,14 @@
 package reciter.pubmed.xmlparser;
 
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
-
-import org.xml.sax.Attributes;
-import org.xml.sax.SAXException;
 import org.xml.sax.helpers.DefaultHandler;
 
 import lombok.extern.slf4j.Slf4j;
 
 /**
  * A SAX handler for parsing the ESearch query from PubMed.
+ *
+ * The live ESearch path parses the JSON response in the controller/service, so
+ * the SAX parsing machinery that previously lived here is no longer invoked.
  *
  * @author Jie
  */
@@ -19,52 +17,6 @@ public class PubmedESearchHandler extends DefaultHandler {
 
     private String webEnv;
     private int count;
-    private boolean bWebEnv;
-    private boolean bCount;
-    private int numCountEncounteredSoFar = 0;
-
-    private static ObjectMapper objectMapper = new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-
-    private StringBuilder chars = new StringBuilder();
-
-    @Override
-    public void startElement(String uri, String localName, String qName, Attributes attributes) throws SAXException {
-
-        chars.setLength(0);
-
-        if (qName.equalsIgnoreCase("WebEnv")) {
-            bWebEnv = true;
-        }
-        if (qName.equalsIgnoreCase("Count") && numCountEncounteredSoFar == 0) {
-            numCountEncounteredSoFar++;
-            bCount = true;
-        }
-    }
-
-    @Override
-    public void characters(char ch[], int start, int length) throws SAXException {
-        if (bWebEnv) {
-            chars.append(ch, start, length);
-        }
-        if (bCount) {
-            chars.append(ch, start, length);
-        }
-    }
-
-    @Override
-    public void endElement(String uri, String localName, String qName) throws SAXException {
-        // WebEnv
-        if (bWebEnv) {
-            webEnv = chars.toString();
-            bWebEnv = false;
-        }
-
-        // Count.
-        if (bCount) {
-            count = Integer.parseInt(chars.toString());
-            bCount = false;
-        }
-    }
 
     public String getWebEnv() {
         return webEnv;


### PR DESCRIPTION
## Summary

Removes provably dead code from the two PubMed XML parsers. Behavior is unchanged.

### `PubmedESearchHandler`
The SAX `startElement`/`characters`/`endElement` machinery was never invoked — the live ESearch path parses the JSON response in the controller/service, and the only remaining reference to this handler is a commented-out line in `PubMedArticleRetrievalService` (`//pubmedXmlQuery.setWebEnv(PubmedESearchHandler.executeESearchQuery(...).getWebenv());`). `executeESearchQuery` does not exist anywhere in the codebase. Removed the dead SAX overrides, their parsing-state fields (`bWebEnv`, `bCount`, `numCountEncounteredSoFar`, `chars`), and the unused `ObjectMapper`. The class is kept (not deleted/emptied) and remains compilable with its `getWebEnv()`/`getCount()` accessors and a clarifying class comment.

### `PubmedEFetchHandler`
- Removed commented-out blocks: the `CoiStatement` startElement stub, the `ArticleIdList` reset stub in `endElement`, the `bPubmedData` `characters` stub, and the `// not used.` CommentsCorrections lines.
- Removed the debug `System.out.println` vestiges in the article-title handling.
- Removed the `bArticleIdPubMed` / `bArticleIdPii` / `bArticleIdDoi` flags. Those `ArticleId` branches only *set* flags that are never *read*, so removing them preserves current behavior: pubmed/pii/doi IDs were already never extracted at the `ArticleId` level. The live `pmc` branch is untouched, and `bArticleId` / `bArticleIdList` (part of the live PMC extraction machinery) are retained.

Closes #126

## Deferred
- Wiring up actual `ArticleId`-level DOI/PII/PMID extraction is intentionally **not** done here — it would change runtime output and needs its own test coverage. The flags were removed (not wired up) so behavior stays identical to current production.
- The whole `PubmedESearchHandler` class is now effectively unused, but per scope it is preserved (not deleted) to keep the change minimal; full removal of the class plus the commented reference line in `PubMedArticleRetrievalService` can be a follow-up.
- A future refactor of the 1322-line `PubmedEFetchHandler` (noted in the issue) is out of scope.

## Testing
Run with `JAVA_HOME` pointed at openjdk@11:
- `mvn -B -ntp clean package -DskipTests` → **BUILD SUCCESS**
- `mvn -B -ntp test -Dtest=PubmedEFetchHandlerTest,PubMedUriParserCallableTest -DfailIfNoTests=false` → **Tests run: 7, Failures: 0, Errors: 0, Skipped: 0 — BUILD SUCCESS**

The live load test (ReCiterPubmedApiLoadTest) was not run (it 403s without a running service).
