### PR TITLE
Promote cleanup to production: dead-code removal in retrieval/parsers + logging fixes (dev → master)

### DIFF
--- a/src/main/java/reciter/controller/PubMedRetrievalToolController.java
+++ b/src/main/java/reciter/controller/PubMedRetrievalToolController.java
@@ -75,16 +75,16 @@ public class PubMedRetrievalToolController {
         // and HTTP/timeout behavior are identical to the article-retrieval path.
         String encodedTerm = URLEncoder.encode(pubMedQuery.toString(), "UTF-8");
         int count = pubMedArticleRetrievalService.getNumberOfPubMedArticles(encodedTerm).getCount();
-        log.info("esearchResults Count :" + count);
+        log.info("esearchResults Count=[{}]", count);
         return count;
     }
 
     private List<PubMedArticle> retrieve(String query, String fields) throws IOException {
         query = URLEncoder.encode(query, "UTF-8");
-        log.info("Retrieving with query=[" + query + "]");
+        log.info("Retrieving with query=[{}]", query);
 
         List<PubMedArticle> pubMedArticles = pubMedArticleRetrievalService.retrieve(query);
-        log.info("retrieved " + pubMedArticles.size() + " PubMed articles using query=[" + query + "]");
+        log.info("Retrieved [{}] PubMed articles using query=[{}]", pubMedArticles.size(), query);
 
         // No field selection requested: return the retrieved articles directly and skip the
         // per-article Squiggly stringify -> readValue round-trip entirely.
@@ -106,7 +106,7 @@ public class PubMedRetrievalToolController {
                 // On a per-item serialization failure, skip the element rather than adding null.
                 result.add(objectMapper.readValue(partialObject, PubMedArticle.class));
             } catch (IOException e) {
-                log.error("Unable to read value from pmid=" + elem.getMedlinecitation().getMedlinecitationpmid().getPmid(), e);
+                log.error("Unable to read value from pmid=[{}]", elem.getMedlinecitation().getMedlinecitationpmid().getPmid(), e);
             }
         });
         return result;

--- a/src/main/java/reciter/pubmed/retriever/PubMedArticleRetrievalService.java
+++ b/src/main/java/reciter/pubmed/retriever/PubMedArticleRetrievalService.java
@@ -5,10 +5,6 @@ import java.io.InputStream;
 import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 
 import javax.xml.XMLConstants;
 import javax.xml.parsers.ParserConfigurationException;
@@ -47,6 +43,14 @@ import reciter.pubmed.xmlparser.PubmedEFetchHandler;
 @Service
 public class PubMedArticleRetrievalService {
 
+    /**
+     * Maximum number of matching articles this service will retrieve for a single query. Queries
+     * matching more than this many articles are hard-refused (see {@link #retrieve(String)}) rather
+     * than fetched: such broad queries indicate an under-specified author search whose results are
+     * not useful to the disambiguation engine and would impose a large, slow load on NCBI. Because
+     * this threshold is well below {@link PubmedXmlQuery#DEFAULT_RETMAX} (10,000), every allowed
+     * query fits in a single EFetch batch, so no pagination is required.
+     */
     private static final int RETRIEVAL_THRESHOLD = 2000;
 
     private static ObjectMapper objectMapper = new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
@@ -87,109 +91,53 @@ public class PubMedArticleRetrievalService {
    }
 
     /**
-     * Initializes and starts threads that handles the retrieval process. Partition the number of articles
-     * into manageable pieces and ask each thread to handle one partition.
+     * Retrieves all PubMed articles matching {@code pubMedQuery}.
+     * <p>
+     * An ESearch determines the matching article count. Because the allowed count is capped at
+     * {@link #RETRIEVAL_THRESHOLD} (2,000), which is well below {@link PubmedXmlQuery#DEFAULT_RETMAX}
+     * (10,000), every allowed query is satisfied by a single EFetch request — there is no need to
+     * paginate over retstart or fan the fetches out across a thread pool. Queries matching more than
+     * the threshold are hard-refused with an {@link IOException}; the message text is matched by
+     * {@code GlobalExceptionHandler} to map the refusal to a 502 response, so it must not change.
      */
     @Retryable(maxAttempts = 7, value = IOException.class,
         backoff = @Backoff(random = true, delay = 1500, maxDelay = 9000), listeners = {"retryListener"})
     public List<PubMedArticle> retrieve(String pubMedQuery) throws IOException {
 
-    	PubmedESearchResult eSearchResult = new PubmedESearchResult();
-    	eSearchResult = getNumberOfPubMedArticles(pubMedQuery);
+        PubmedESearchResult eSearchResult = getNumberOfPubMedArticles(pubMedQuery);
+        int numberOfPubmedArticles = eSearchResult.getCount();
 
-        int numberOfPubmedArticles = eSearchResult.getCount();//getNumberOfPubMedArticles(pubMedQuery);
-        List<PubMedArticle> pubMedArticles = new ArrayList<>();
-
-        if (numberOfPubmedArticles <= RETRIEVAL_THRESHOLD) {
-            ExecutorService executor = Executors.newWorkStealingPool();
-        	//ScheduledExecutorService executor = (ScheduledExecutorService) Executors.newScheduledThreadPool(10);
-
-
-            // Get the count (number of publications for this query).
-            PubmedXmlQuery pubmedXmlQuery = new PubmedXmlQuery();
-            pubmedXmlQuery.setTerm(pubMedQuery);
-
-            log.info("retMax=[{}], pubMedQuery=[{}], numberOfPubmedArticles=[{}].",
-                    pubmedXmlQuery.getRetMax(), pubMedQuery, numberOfPubmedArticles);
-
-            // Retrieve the publications retMax records at one time and store to disk.
-            int currentRetStart = 0;
-            /*Retryer<List<PubMedArticle>> retryer = RetryerBuilder.<List<PubMedArticle>>newBuilder()
-                    .retryIfResult(Predicates.<List<PubMedArticle>>isNull())
-                    .retryIfExceptionOfType(IOException.class)
-                    .retryIfRuntimeException()
-                    .withWaitStrategy(WaitStrategies.fibonacciWait(100L, 15L, TimeUnit.SECONDS))
-                    .withStopStrategy(StopStrategies.stopAfterAttempt(15))
-                    .build();*/
-
-            //List<RetryerCallable<List<PubMedArticle>>> callables = new ArrayList<RetryerCallable<List<PubMedArticle>>>();
-            List<Callable<List<PubMedArticle>>> callables = new ArrayList<>();
-
-
-
-            // Use the retstart value to iteratively fetch all XMLs.
-            while (numberOfPubmedArticles > 0) {
-                // Get webenv value.
-                pubmedXmlQuery.setRetStart(currentRetStart);
-                //String eSearchUrl = pubmedXmlQuery.buildESearchQuery();
-
-                //pubmedXmlQuery.setWebEnv(PubmedESearchHandler.executeESearchQuery(pubmedXmlQuery.getTerm()).getWebenv());
-                if(eSearchResult.getWebenv() != null) {
-                	pubmedXmlQuery.setWebEnv(eSearchResult.getWebenv());
-                }
-
-                // Use the webenv value to retrieve xml.
-                String eFetchUrl = pubmedXmlQuery.buildEFetchQuery();
-                log.info("eFetchUrl=[{}].", PubmedXmlQuery.redactApiKey(eFetchUrl));
-
-
-
-                try {
-                	//PubMedUriParserCallable callable = new PubMedUriParserCallable(new PubmedEFetchHandler(), getSaxParser(), new InputSource(eFetchUrl));
-                	//RetryerCallable<List<PubMedArticle>> retryerCallable = retryer.wrap(callable);
-                	//callables.add(retryerCallable);
-                    callables.add(new PubMedUriParserCallable(new PubmedEFetchHandler(), getSaxParser(), new InputSource(eFetchUrl)));
-				} catch (ParserConfigurationException | SAXException e) {
-					log.error("Exception", e);
-				}
-
-                // Update the retstart value.
-                currentRetStart += pubmedXmlQuery.getRetMax();
-                pubmedXmlQuery.setRetStart(currentRetStart);
-                numberOfPubmedArticles -= pubmedXmlQuery.getRetMax();
-            }
-
-
-			/*
-			 * for(Callable<List<PubMedArticle>> callable: callables) {
-			 * executor.schedule(callable, 5, TimeUnit.SECONDS); }
-			 */
-
-
-            try {
-                List<java.util.concurrent.Future<List<PubMedArticle>>> futures = executor.invokeAll(callables);
-                for (java.util.concurrent.Future<List<PubMedArticle>> future : futures) {
-                    try {
-                        pubMedArticles.addAll(future.get());
-                    } catch (ExecutionException e) {
-                        log.error("Unable to retrieve result using future get.");
-                        Throwable cause = e.getCause();
-                        if (cause instanceof IOException) {
-                            throw (IOException) cause;
-                        }
-                        throw new IOException("Failed to fetch/parse EFetch result", cause);
-                    }
-                }
-            } catch (InterruptedException e) {
-                log.error("Unable to invoke callable.", e);
-                Thread.currentThread().interrupt();
-            } finally {
-                executor.shutdownNow();
-            }
-        } else {
+        if (numberOfPubmedArticles > RETRIEVAL_THRESHOLD) {
             throw new IOException("Number of PubMed Articles retrieved " + numberOfPubmedArticles + " exceeded the threshold level " + RETRIEVAL_THRESHOLD);
         }
-        return pubMedArticles;
+
+        // Single EFetch using the WebEnv from the ESearch above. The allowed count always fits in
+        // one retMax-sized batch, so no retstart pagination loop is required.
+        PubmedXmlQuery pubmedXmlQuery = new PubmedXmlQuery();
+        pubmedXmlQuery.setTerm(pubMedQuery);
+        pubmedXmlQuery.setRetStart(0);
+        if (eSearchResult.getWebenv() != null) {
+            pubmedXmlQuery.setWebEnv(eSearchResult.getWebenv());
+        }
+
+        String eFetchUrl = pubmedXmlQuery.buildEFetchQuery();
+        log.info("retMax=[{}], pubMedQuery=[{}], numberOfPubmedArticles=[{}], eFetchUrl=[{}].",
+                pubmedXmlQuery.getRetMax(), pubMedQuery, numberOfPubmedArticles,
+                PubmedXmlQuery.redactApiKey(eFetchUrl));
+
+        try {
+            PubMedUriParserCallable callable =
+                    new PubMedUriParserCallable(new PubmedEFetchHandler(), getSaxParser(), new InputSource(eFetchUrl));
+            return new ArrayList<>(callable.call());
+        } catch (IOException e) {
+            throw e;
+        } catch (ParserConfigurationException | SAXException e) {
+            log.error("Unable to configure SAX parser for EFetch.", e);
+            throw new IOException("Failed to configure EFetch parser", e);
+        } catch (Exception e) {
+            log.error("Unable to fetch/parse EFetch result.", e);
+            throw new IOException("Failed to fetch/parse EFetch result", e);
+        }
     }
 
     /**
@@ -221,14 +169,16 @@ public class PubMedArticleRetrievalService {
     protected PubmedESearchResult executeESearch(String term) throws IOException {
         PubmedXmlQuery pubmedXmlQuery = new PubmedXmlQuery(term);
         pubmedXmlQuery.setRetStart(0);
-        log.info("ESearch Query=[{}]", PubmedXmlQuery.redactApiKey(pubmedXmlQuery.buildESearchQuery()));
 
+        // The request is an HTTP POST to ESEARCH_BASE_URL with form-encoded params; log the
+        // endpoint actually called (with api_key redacted) and the term, not a discarded GET URL.
         String postUrl;
         if (pubmedXmlQuery.getApiKey() != null && !pubmedXmlQuery.getApiKey().isEmpty()) {
             postUrl = PubmedXmlQuery.ESEARCH_BASE_URL + "?api_key=" + pubmedXmlQuery.getApiKey();
         } else {
             postUrl = PubmedXmlQuery.ESEARCH_BASE_URL;
         }
+        log.info("ESearch POST url=[{}], term=[{}]", PubmedXmlQuery.redactApiKey(postUrl), term);
 
         PubmedESearchResult eSearchResult = new PubmedESearchResult();
 
@@ -266,7 +216,7 @@ public class PubMedArticleRetrievalService {
         }
 
         eSearchResult = objectMapper.treeToValue(json, PubmedESearchResult.class);
-        log.info("esearchResults Count :" + eSearchResult.getCount());
+        log.info("esearchResults Count=[{}]", eSearchResult.getCount());
         return eSearchResult;
     }
 
@@ -312,13 +262,13 @@ public class PubMedArticleRetrievalService {
 
         if (headerRateLimit != null && headerRateLimit.length > 0 && headerRateLimit[0] != null
                 && headerRateLimitRemaining != null && headerRateLimitRemaining.length > 0 && headerRateLimitRemaining[0] != null) {
-            log.info("Query : " + query + " " + headerRateLimit[0].toString() + " " + headerRateLimitRemaining[0].toString());
+            log.info("Query=[{}] {} {}", query, headerRateLimit[0].toString(), headerRateLimitRemaining[0].toString());
         }
 
         if (headerRateLimitRemaining != null && headerRateLimitRemaining.length > 0 && headerRateLimitRemaining[0] != null
                 && Integer.parseInt(headerRateLimitRemaining[0].getValue()) == 0) {
             if (headerRetryAfter != null && headerRetryAfter.length > 0 && headerRetryAfter[0] != null) {
-                log.info("Query : " + query + " " + headerRetryAfter[0].toString());
+                log.info("Query=[{}] {}", query, headerRetryAfter[0].toString());
                 try {
                     Thread.sleep(Long.parseLong(headerRetryAfter[0].getValue()) * 1000L);
                 } catch (InterruptedException e) {

--- a/src/main/java/reciter/pubmed/retriever/PubMedArticleRetrievalService.java
+++ b/src/main/java/reciter/pubmed/retriever/PubMedArticleRetrievalService.java
@@ -111,6 +111,12 @@ public class PubMedArticleRetrievalService {
             throw new IOException("Number of PubMed Articles retrieved " + numberOfPubmedArticles + " exceeded the threshold level " + RETRIEVAL_THRESHOLD);
         }
 
+        // No matches: return empty without an EFetch round-trip (the old pagination loop, gated on
+        // "while (count > 0)", likewise issued no fetch for a zero-result query).
+        if (numberOfPubmedArticles == 0) {
+            return new ArrayList<>();
+        }
+
         // Single EFetch using the WebEnv from the ESearch above. The allowed count always fits in
         // one retMax-sized batch, so no retstart pagination loop is required.
         PubmedXmlQuery pubmedXmlQuery = new PubmedXmlQuery();

--- a/src/main/java/reciter/pubmed/xmlparser/PubmedEFetchHandler.java
+++ b/src/main/java/reciter/pubmed/xmlparser/PubmedEFetchHandler.java
@@ -141,9 +141,6 @@ public class PubmedEFetchHandler extends DefaultHandler {
     private boolean bPublicationStatus;
     private boolean bArticleIdList;
     private boolean bArticleId;
-    private boolean bArticleIdPubMed;
-    private boolean bArticleIdPii;
-    private boolean bArticleIdDoi;
     private boolean bArticleIdPmc;
     private boolean bGrantList;
     private boolean bGrant;
@@ -590,12 +587,7 @@ public class PubmedEFetchHandler extends DefaultHandler {
             }
             
 
-            // not used.
-            //      if (qName.equalsIgnoreCase("RefSource") && bCommentsCorrections) {
-            //          bCommentsCorrectionsRefSource = true;
-            //      }
             if (qName.equalsIgnoreCase("PMID") && bCommentsCorrections) {
-                //          bCommentsCorrectionsPmidVersion = true;
                 bCommentsCorrectionsPmid = true;
             }
 
@@ -641,25 +633,14 @@ public class PubmedEFetchHandler extends DefaultHandler {
                 bArticleIdList = true;
             }
 
-            if (qName.equalsIgnoreCase("ArticleId") && !bReferenceArticleIdList && !bReferenceArticleId && !bReference) {  
+            if (qName.equalsIgnoreCase("ArticleId") && !bReferenceArticleIdList && !bReferenceArticleId && !bReference) {
                 bArticleId = true;
                 String idType = getArticleIdType(attributes);
-                if ("pubmed".equals(idType)) {
-                    bArticleIdPubMed = true;
-                } else if ("pii".equals(idType)) {
-                    bArticleIdPii = true;
-                } else if ("doi".equals(idType)) {
-                    bArticleIdDoi = true;
-                } else if ("pmc".equals(idType)) {
+                if ("pmc".equals(idType)) {
                     pubmedArticle.getPubmeddata().setArticleIdList(new ArticleIdList());
                     bArticleIdPmc = true;
                 }
             }
-            /*if(qName.equalsIgnoreCase("CoiStatement"))
-            {
-            	 String coiStatment = chars.toString();
-                 pubmedArticle.getMedlinecitation().setCoiStatement(coiStatment);
-            }*/
         }
     }
 
@@ -689,13 +670,7 @@ public class PubmedEFetchHandler extends DefaultHandler {
             
                 // Delete certain non-printable, hexadecimal characters
                 articleTitle = articleTitle.replaceAll("[\u2029\u0099\u2003]", "");
-            
-                // Output the encoding being used
-                // System.out.println("Encoding: " + Charset.defaultCharset().displayName());
-            
-                // Output the value of articleTitle
-                // System.out.println("Article Title: " + articleTitle);
-            
+
                 // Set the title of the article.
                 pubmedArticle.getMedlinecitation().getArticle().setArticletitle(articleTitle); 
                 bArticleTitle = false;
@@ -1127,21 +1102,11 @@ public class PubmedEFetchHandler extends DefaultHandler {
                 bReference = false;
             }
             if(qName.equalsIgnoreCase("CoiStatement") && bCoiStatement) {
-            	
+
             	  String coiStatement = chars.toString();
-                  pubmedArticle.getMedlinecitation().setCoiStatement(coiStatement); 
+                  pubmedArticle.getMedlinecitation().setCoiStatement(coiStatement);
                   bCoiStatement = false;
             }
-
-            /*if (qName.equalsIgnoreCase("ArticleIdList")) {
-                bArticleIdList = false;
-                bArticleId = false;
-                bArticleIdPubMed = false;
-                bArticleIdPii = false;
-                bArticleIdDoi = false;
-            }*/
-
-            
         }
     }
 
@@ -1302,10 +1267,5 @@ public class PubmedEFetchHandler extends DefaultHandler {
         if(bCoiStatement) {
         	chars.append(ch, start, length);
         }
-        	
-        
-        /*if (bPubmedData) {
-            chars.append(ch, start, length);
-        }*/
     }
 }

--- a/src/main/java/reciter/pubmed/xmlparser/PubmedESearchHandler.java
+++ b/src/main/java/reciter/pubmed/xmlparser/PubmedESearchHandler.java
@@ -1,16 +1,14 @@
 package reciter.pubmed.xmlparser;
 
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
-
-import org.xml.sax.Attributes;
-import org.xml.sax.SAXException;
 import org.xml.sax.helpers.DefaultHandler;
 
 import lombok.extern.slf4j.Slf4j;
 
 /**
  * A SAX handler for parsing the ESearch query from PubMed.
+ *
+ * The live ESearch path parses the JSON response in the controller/service, so
+ * the SAX parsing machinery that previously lived here is no longer invoked.
  *
  * @author Jie
  */
@@ -19,52 +17,6 @@ public class PubmedESearchHandler extends DefaultHandler {
 
     private String webEnv;
     private int count;
-    private boolean bWebEnv;
-    private boolean bCount;
-    private int numCountEncounteredSoFar = 0;
-
-    private static ObjectMapper objectMapper = new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-
-    private StringBuilder chars = new StringBuilder();
-
-    @Override
-    public void startElement(String uri, String localName, String qName, Attributes attributes) throws SAXException {
-
-        chars.setLength(0);
-
-        if (qName.equalsIgnoreCase("WebEnv")) {
-            bWebEnv = true;
-        }
-        if (qName.equalsIgnoreCase("Count") && numCountEncounteredSoFar == 0) {
-            numCountEncounteredSoFar++;
-            bCount = true;
-        }
-    }
-
-    @Override
-    public void characters(char ch[], int start, int length) throws SAXException {
-        if (bWebEnv) {
-            chars.append(ch, start, length);
-        }
-        if (bCount) {
-            chars.append(ch, start, length);
-        }
-    }
-
-    @Override
-    public void endElement(String uri, String localName, String qName) throws SAXException {
-        // WebEnv
-        if (bWebEnv) {
-            webEnv = chars.toString();
-            bWebEnv = false;
-        }
-
-        // Count.
-        if (bCount) {
-            count = Integer.parseInt(chars.toString());
-            bCount = false;
-        }
-    }
 
     public String getWebEnv() {
         return webEnv;


### PR DESCRIPTION
## Promote cleanup to production (dev → master)

Brings the three reviewed, CI-green low-risk cleanups from `dev` (merged via #139 and #140) up to `master`.

### Contents (net: 4 files, +69 / −201 — pure dead-code removal)
- **#125** — `PubMedArticleRetrievalService.retrieve` simplified to a single ESearch + single EFetch; removed the dead pagination loop and single-task work-stealing pool (the 2000 threshold is below the 10,000 retMax, so the loop only ever ran once). The >2000 hard-refuse `IOException` message text is preserved exactly (still mapped to 502 by `GlobalExceptionHandler`), and a zero-result query returns empty without an EFetch round-trip.
- **#131** — SLF4J `{}` placeholders on log statements that previously dropped their values; fixed the misleading ESearch-URL log (now logs the POST endpoint actually called, api_key redacted).
- **#126** — removed dead parser code: `PubmedESearchHandler` SAX machinery (the live path parses JSON), never-read `bArticleIdPubMed/Pii/Doi` flags, and commented-out / `println` vestiges in `PubmedEFetchHandler`.

Closes #125
Closes #126
Closes #131

### Testing
- #139 and #140 each passed JDK 11 `mvn -B -ntp clean package` + the parser unit tests (`PubmedEFetchHandlerTest`, `PubMedUriParserCallableTest`, 7/7) before merge to `dev`.
- GitHub Actions `build` and Orca security scans were green on both.

### Note
- AWS CodeBuild (PubMedService) is a pre-existing always-red check on master PRs (red on #132–#138 alike); the authoritative gate is the GitHub Actions `build` check.