### PR TITLE
CRITICAL: fix EFetch parsing broken by XXE hardening — every live retrieval returns 500

### DIFF
--- a/src/main/java/reciter/pubmed/retriever/PubMedArticleRetrievalService.java
+++ b/src/main/java/reciter/pubmed/retriever/PubMedArticleRetrievalService.java
@@ -72,9 +72,13 @@ public class PubMedArticleRetrievalService {
         public SAXParserFactory initialValue() {
             try {
                 SAXParserFactory factory = SAXParserFactory.newInstance();
-                // Harden against XXE: disallow DOCTYPE declarations and disable external
-                // entity/DTD resolution. This is defense-in-depth for an XML-parsing service.
-                factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+                // Harden against XXE while still accepting the DOCTYPE that NCBI includes in every
+                // EFetch response (<!DOCTYPE PubmedArticleSet PUBLIC ... pubmed_*.dtd>). The DOCTYPE
+                // declaration itself is permitted, but all external general/parameter entity and
+                // external/remote DTD resolution is disabled (plus secure processing), which closes
+                // the XXE vector without rejecting valid PubMed XML. Do NOT set
+                // disallow-doctype-decl=true here: it rejects every real EFetch response.
+                factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", false);
                 factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
                 factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
                 factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);


### PR DESCRIPTION
## Critical: live PubMed retrieval is broken on `dev`/`master`

#114's SAX hardening (shipped to `master` in #135) set
`disallow-doctype-decl=true`. Every real NCBI EFetch response begins with a
DOCTYPE:

```
<!DOCTYPE PubmedArticleSet PUBLIC "-//NLM//DTD PubMedArticle ..." "https://dtd.nlm.nih.gov/.../pubmed_*.dtd">
```

so the parser throws `org.xml.sax.SAXParseException: DOCTYPE is disallowed ...`
→ `IOException` → retried 7× → **HTTP 500**. The service returns **no articles**
for any live query (`/pubmed/query/*`, complex query, and the retrieval path of
the count→fetch flow).

### Why the test suite missed it
- The parser unit tests parse local fixtures that have **no DOCTYPE**.
- The live load test (`ReCiterPubmedApiLoadTest`/`LoadTest`) is skipped — it 403s without a running service.

So `mvn package` + unit tests are green while the live path is 100% broken. This was found by **booting the app and running a real query**.

### Fix
Set `disallow-doctype-decl=false` to accept the (benign) DOCTYPE declaration, while keeping the actual XXE protections:
- `external-general-entities=false`
- `external-parameter-entities=false`
- `load-external-dtd=false` (no remote DTD fetch)
- `FEATURE_SECURE_PROCESSING=true`

No external entities or DTDs are ever resolved, so the XXE vector that #114 targeted stays closed; only the DOCTYPE *declaration* is permitted. This is the standard configuration for parsing documents that legitimately carry a DOCTYPE.

### Testing (runtime-verified)
- JDK 11 `mvn -B -ntp clean package -Dtest=PubmedEFetchHandlerTest,PubMedUriParserCallableTest` → BUILD SUCCESS, 7/7.
- Booted the jar on :8083. Before this change `GET /pubmed/query/Kukafka R[au]` returned **HTTP 500**; after, it returns **HTTP 200 with 120 parsed articles** (titles deserialized correctly).

### Note
This is the regression from #114 (closed). Recommend fast-tracking to `master` once reviewed — the same break is on prod source. A follow-up should add a small parser test fixture that includes a DOCTYPE so CI guards against this.