### PR TITLE
Dependency hardening: exclude transitive AWS SDK (#119) + patch Jackson/TestNG CVEs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,16 +34,24 @@
             <artifactId>squiggly-filter-jackson</artifactId>
             <version>1.3.18</version>
         </dependency>
+        <!-- Jackson pinned to the latest patched 2.12.x to clear known CVEs while staying on the
+             2.12 line (binary-compatible with Spring Boot 2.5's managed Jackson). databind 2.12.7.1
+             is the security hotfix on top of the 2.12.7 core/annotations. -->
         <!-- https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-annotations -->
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>2.12.3</version>
+            <version>2.12.7</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.12.7</version>
         </dependency>
         <dependency>
 		    <groupId>com.fasterxml.jackson.core</groupId>
 		    <artifactId>jackson-databind</artifactId>
-		    <version>2.12.3</version> <!-- Use the latest version -->
+		    <version>2.12.7.1</version>
 		</dependency>
         <dependency>
 			<groupId>io.springfox</groupId>
@@ -68,7 +76,7 @@
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
-            <version>7.4.0</version>
+            <version>7.5.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -79,6 +87,13 @@
         		<exclusion>
         			<groupId>org.slf4j</groupId>
         			<artifactId>slf4j-simple</artifactId>
+        		</exclusion>
+        		<!-- AWS SDK v1 is not used at runtime by this service (the only direct usage was
+        		     removed in #132); exclude the transitive DynamoDB SDK so it is not bundled in
+        		     the fat jar. This cascades to aws-java-sdk-s3/kms/core and jmespath-java. -->
+        		<exclusion>
+        			<groupId>com.amazonaws</groupId>
+        			<artifactId>aws-java-sdk-dynamodb</artifactId>
         		</exclusion>
         	</exclusions>
         </dependency>


### PR DESCRIPTION
## Dependency hardening

### #119 — exclude transitively-bundled AWS SDK
AWS SDK v1 was still shipped in the fat jar transitively via
`reciter-pubmed-model:2.0.3 → aws-java-sdk-dynamodb:1.11.34` (the *direct* declaration and the only `com.amazonaws` usage were already removed in #132). Added an `<exclusion>` on `reciter-pubmed-model`; this cascades to drop `aws-java-sdk-s3`, `-kms`, `-core`, and `jmespath-java`.

`mvn dependency:tree -Dincludes=com.amazonaws` → **empty** after the change.

Closes #119.

### Dependabot CVEs (5 high)
- `jackson-databind` 2.12.3 → **2.12.7.1**, `jackson-core`/`jackson-annotations` → **2.12.7** (added an explicit `jackson-core` pin to keep the trio aligned). Clears all 4 jackson-databind highs; stays on the 2.12 line so it's binary-compatible with Spring Boot 2.5's managed Jackson.
- `testng` 7.4.0 → **7.5.1** (path-traversal advisory). Supersedes the stale Dependabot PR **#91** — close that once this merges.

### Testing
- JDK 11 `mvn -B -ntp clean package` → BUILD SUCCESS; parser/callable tests 7/7.
- Dependency trees verified: AWS subtree gone; jackson at 2.12.7/2.12.7.1; testng 7.5.1.
- **Runtime:** booted the jar on :8083 — app starts clean and the request path runs through ESearch + EFetch into the SAX parser with **no AWS `NoClassDefFoundError`/classloading failure**, confirming the exclusion is runtime-safe.

> Note: while runtime-verifying this branch I found an unrelated **critical** bug — #114's `disallow-doctype-decl=true` rejects every real EFetch response (500 on all live queries). Fixed separately in #143; that fix is required for a query to return articles end-to-end.