### PR TITLE
PROD HOTFIX: promote EFetch DOCTYPE parsing fix to master (restores all live retrieval)

### DIFF
--- a/src/main/java/reciter/pubmed/retriever/PubMedArticleRetrievalService.java
+++ b/src/main/java/reciter/pubmed/retriever/PubMedArticleRetrievalService.java
@@ -72,9 +72,13 @@ public class PubMedArticleRetrievalService {
         public SAXParserFactory initialValue() {
             try {
                 SAXParserFactory factory = SAXParserFactory.newInstance();
-                // Harden against XXE: disallow DOCTYPE declarations and disable external
-                // entity/DTD resolution. This is defense-in-depth for an XML-parsing service.
-                factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+                // Harden against XXE while still accepting the DOCTYPE that NCBI includes in every
+                // EFetch response (<!DOCTYPE PubmedArticleSet PUBLIC ... pubmed_*.dtd>). The DOCTYPE
+                // declaration itself is permitted, but all external general/parameter entity and
+                // external/remote DTD resolution is disabled (plus secure processing), which closes
+                // the XXE vector without rejecting valid PubMed XML. Do NOT set
+                // disallow-doctype-decl=true here: it rejects every real EFetch response.
+                factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", false);
                 factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
                 factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
                 factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);


### PR DESCRIPTION
## Production hotfix promotion (dev → master)

Promotes the critical fix from #143 to `master`. Net diff is a single file (+7/−3).

**Impact:** on current `master`, #114's `disallow-doctype-decl=true` rejects every real NCBI EFetch response (which always carries `<!DOCTYPE PubmedArticleSet ...>`), so every live `/pubmed/query` returns HTTP 500 with no articles. This promotion restores retrieval.

**Fix:** allow the DOCTYPE declaration while keeping external general/parameter entities and external/remote DTD loading disabled (plus secure processing) — XXE stays closed; valid PubMed XML parses.

### Testing (runtime-verified before merge to dev)
- JDK 11 `mvn clean package` + parser tests 7/7 green; GitHub Actions `build` green.
- Booted the jar: `GET /pubmed/query/Kukafka R[au]` returned **HTTP 200 with 120 parsed articles** (was HTTP 500 before the fix).

> AWS CodeBuild (PubMedService) is the known pre-existing always-red check on master PRs — not a regression; the authoritative gate is GitHub Actions `build`.