### PR TITLE
Bump Spring Boot 2.5.0 → 2.7.18 (stay on javax) + Springfox path-matching fix (#113)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.5.0</version>
+        <version>2.7.18</version>
     </parent>
 
     <properties>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,5 +1,9 @@
 server.port=5000
 
+# Spring Boot 2.6+ defaults to PATH_PATTERN_PARSER, which fails at startup with
+# Springfox 3.0.0. Keep the legacy AntPathMatcher so Swagger/Springfox loads.
+spring.mvc.pathmatch.matching-strategy=ANT_PATH_MATCHER
+
 # Logging goes to stdout/console only (see logback-spring.xml) so it is collected
 # into CloudWatch from the container's stdout on EKS (Fluent Bit / Container Insights).
 # File logging is intentionally NOT configured: an in-container log file is ephemeral


### PR DESCRIPTION
## Spring Boot 2.5.0 → 2.7.18 (bounded, stays on javax)

Near-drop-in minor bump per #113. Stays on **javax** (Tomcat 9.0.83, Spring 5.3.31) and harvests the last/best-patched Boot 2.x transitives. The full Boot 3 / Java 17 / jakarta jump remains the deferred epic (#136).

### Changes
- `pom.xml`: `spring-boot-starter-parent` 2.5.0 → **2.7.18**.
- `application.properties`: add `spring.mvc.pathmatch.matching-strategy=ANT_PATH_MATCHER`. Boot 2.6+ defaults to `PATH_PATTERN_PARSER`, which breaks **Springfox 3.0.0** at startup; this keeps the legacy matcher so Swagger/Springfox loads.

Closes #113.

### Testing (runtime-verified, JDK 11)
- `mvn -B -ntp clean package` → BUILD SUCCESS; parser/callable tests 7/7.
- Bundled versions confirmed in the jar: `spring-boot-autoconfigure-2.7.18`, `spring-core-5.3.31`, `tomcat-embed-core-9.0.83`.
- Booted the jar on :8083:
  - `GET /pubmed/ping` → **200** (context loads, ~2.1s startup).
  - `GET /v3/api-docs` → **200** (12.9 KB) and `GET /swagger-ui/index.html` → **200** — Springfox works under 2.7 with the matcher fix.
  - `GET /pubmed/query/Kukafka R[au]` → **200 with 120 parsed articles** (end-to-end; this branch is based on `dev`, which includes the #143 DOCTYPE fix).
- Jackson 2.12.3 (pinned on `dev`) ran fine under Boot 2.7 — no runtime/classpath errors.

### Coordination notes
- Both this PR and #144 edit `pom.xml`, but in **different regions** (parent `<version>` vs `<dependencies>`), so they should merge without conflict.
- **Recommended tiny follow-up:** once both this and #144 land, drop the explicit `jackson-databind/core/annotations` pins so Boot 2.7's BOM manages Jackson at its tested **2.13.x** (also CVE-clear) instead of carrying explicit 2.12.7.1 pins. Not required (2.12.7.1 works), just cleaner.
- Per #113, this needed runtime verification (the Springfox break is a startup-only failure) — done above.