### PR TITLE
Fix broken prod/dev deploy: modernize CodeBuild buildspecs for a current image

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -3,7 +3,7 @@ version: 0.2
 phases:
   install:
     runtime-versions:
-      java: openjdk11
+      java: corretto11
     commands:
       - echo Nothing to do in the install phase...
   pre_build:

--- a/k8-buildspec.yml
+++ b/k8-buildspec.yml
@@ -3,9 +3,12 @@ version: 0.2
 phases:
   install:
     runtime-versions:
-      java: openjdk11
+      java: corretto11
     commands:
-      - kubectl version --short --client   
+      # Modern CodeBuild images do not bundle kubectl; install a pinned client.
+      - curl -sSLo /usr/local/bin/kubectl https://dl.k8s.io/release/v1.29.10/bin/linux/amd64/kubectl
+      - chmod +x /usr/local/bin/kubectl
+      - kubectl version --client
       - java -version
   pre_build:
       commands:
@@ -37,7 +40,8 @@ phases:
           if expr "${BRANCH}" : ".*master" >/dev/null; then
             sed -i.bak -e 's@NAMESPACE@'"reciter"'@' -e 's@ENVCONFIG@'"env-config-prod"'@'  -e 's@APPNAME@'"reciter-pubmed-prod"'@' -e 's@HPANAME@'"hpa-reciter-pubmed-prod"'@' -e 's@ENVIRONMENT_LABEL@'"prod"'@' kubernetes/k8-deployment.yaml;
           fi
-        - $(aws ecr get-login --no-include-email)
+        # AWS CLI v2 (on modern images) replaces `aws ecr get-login` with get-login-password.
+        - aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin ${REPOSITORY_URI%%/*}
         - cat ./kubernetes/k8-deployment.yaml
   build:
     commands:


### PR DESCRIPTION
## Why
The `PubMedService` CodeBuild project (used by **both** the `…-Dev` and `…-prod` pipelines' Build stage) runs on the deprecated **`aws/codebuild/standard:3.0`** image (Ubuntu 18.04, EOL Apr 2023). Its outdated TLS truststore intermittently fails to authenticate Maven Central:
```
Could not transfer artifact org.springframework.boot:spring-boot-starter-web:jar:2.5.0 ... peer not authenticated
```
This is the long-standing always-red `AWS CodeBuild (PubMedService)` check, and it's why **no deploy has reached prod in ~11 months** (live prod still runs `…:master-374.2025-07-03…c73d349`).

## What
Move the project to a maintained image (`aws/codebuild/amazonlinux2-x86_64-standard:5.0`, set on the project itself), which requires three image-coupled buildspec edits (here, in `k8-buildspec.yml` + `buildspec.yml`):
- `runtime-versions: java: openjdk11 → corretto11` (modern images dropped `openjdk11`)
- install `kubectl` explicitly (not bundled on modern images) and drop the removed `--short` flag
- `aws ecr get-login` (CLI v1) → `aws ecr get-login-password | docker login` (CLI v2)

No deploy logic (docker build/push, `kubectl set image`) is otherwise changed.

## Status / testing
⚠️ **Pending validation.** The image bump (`update-project`) and a validation build act on the shared prod-deploy project, so they're being done carefully and confirmed green on the **Dev** pipeline (manual-approval gated) before prod. This PR is the code half; the project image change is applied separately.

## Coordination
- The project-image change (`aws codebuild update-project --name PubMedService --image …`) is a console/CLI action, not in this repo (the project is not under the current CDK — see findings).
- Overlaps with #142 (also edits these buildspecs, different lines — the `-Dtest` build command); should merge cleanly.