### PR TITLE
Promote to production: deploy-pipeline fix + Boot 2.7 + dep/CVE hardening + CI test coverage (dev → master)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,4 +22,4 @@ jobs:
       # (ReCiterPubmedApiLoadTest / LoadTest) which require a running
       # service on localhost:5000 and would otherwise fail the build.
       - name: Build and test
-        run: mvn -B -ntp clean package -Dtest=PubmedEFetchHandlerTest,PubMedUriParserCallableTest
+        run: mvn -B -ntp clean package -Dtest=PubmedEFetchHandlerTest,PubMedUriParserCallableTest,PubMedArticleRetrievalServiceTest -DfailIfNoTests=false

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -3,7 +3,7 @@ version: 0.2
 phases:
   install:
     runtime-versions:
-      java: openjdk11
+      java: corretto11
     commands:
       - echo Nothing to do in the install phase...
   pre_build:

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -12,7 +12,9 @@ phases:
   build:
     commands:
       - echo Build started on `date`
-      - mvn clean install -Dmaven.test.skip=true
+      # Run the curated unit tests while excluding the live load tests
+      # (ReCiterPubmedApiLoadTest / LoadTest), which 403 without a running service.
+      - mvn clean install -Dtest=PubmedEFetchHandlerTest,PubMedUriParserCallableTest,PubMedArticleRetrievalServiceTest -DfailIfNoTests=false
   post_build:
     commands:
       - echo Build completed on `date`

--- a/k8-buildspec.yml
+++ b/k8-buildspec.yml
@@ -3,9 +3,12 @@ version: 0.2
 phases:
   install:
     runtime-versions:
-      java: openjdk11
+      java: corretto11
     commands:
-      - kubectl version --short --client   
+      # Modern CodeBuild images do not bundle kubectl; install a pinned client.
+      - curl -sSLo /usr/local/bin/kubectl https://dl.k8s.io/release/v1.29.10/bin/linux/amd64/kubectl
+      - chmod +x /usr/local/bin/kubectl
+      - kubectl version --client
       - java -version
   pre_build:
       commands:
@@ -37,7 +40,8 @@ phases:
           if expr "${BRANCH}" : ".*master" >/dev/null; then
             sed -i.bak -e 's@NAMESPACE@'"reciter"'@' -e 's@ENVCONFIG@'"env-config-prod"'@'  -e 's@APPNAME@'"reciter-pubmed-prod"'@' -e 's@HPANAME@'"hpa-reciter-pubmed-prod"'@' -e 's@ENVIRONMENT_LABEL@'"prod"'@' kubernetes/k8-deployment.yaml;
           fi
-        - $(aws ecr get-login --no-include-email)
+        # AWS CLI v2 (on modern images) replaces `aws ecr get-login` with get-login-password.
+        - aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin ${REPOSITORY_URI%%/*}
         - cat ./kubernetes/k8-deployment.yaml
   build:
     commands:

--- a/k8-buildspec.yml
+++ b/k8-buildspec.yml
@@ -41,7 +41,9 @@ phases:
         - cat ./kubernetes/k8-deployment.yaml
   build:
     commands:
-      - mvn clean install -Dmaven.test.skip=true
+      # Run the curated unit tests while excluding the live load tests
+      # (ReCiterPubmedApiLoadTest / LoadTest), which 403 without a running service.
+      - mvn clean install -Dtest=PubmedEFetchHandlerTest,PubMedUriParserCallableTest,PubMedArticleRetrievalServiceTest -DfailIfNoTests=false
       - |
         if expr "${BRANCH}" : ".*master" >/dev/null || expr "${BRANCH}" : ".*dev" >/dev/null; then
           docker build --tag $REPOSITORY_URI:$TAG .

--- a/pom.xml
+++ b/pom.xml
@@ -34,16 +34,24 @@
             <artifactId>squiggly-filter-jackson</artifactId>
             <version>1.3.18</version>
         </dependency>
+        <!-- Jackson pinned to the latest patched 2.12.x to clear known CVEs while staying on the
+             2.12 line (binary-compatible with Spring Boot 2.5's managed Jackson). databind 2.12.7.1
+             is the security hotfix on top of the 2.12.7 core/annotations. -->
         <!-- https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-annotations -->
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>2.12.3</version>
+            <version>2.12.7</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.12.7</version>
         </dependency>
         <dependency>
 		    <groupId>com.fasterxml.jackson.core</groupId>
 		    <artifactId>jackson-databind</artifactId>
-		    <version>2.12.3</version> <!-- Use the latest version -->
+		    <version>2.12.7.1</version>
 		</dependency>
         <dependency>
 			<groupId>io.springfox</groupId>
@@ -68,7 +76,7 @@
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
-            <version>7.4.0</version>
+            <version>7.5.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -79,6 +87,13 @@
         		<exclusion>
         			<groupId>org.slf4j</groupId>
         			<artifactId>slf4j-simple</artifactId>
+        		</exclusion>
+        		<!-- AWS SDK v1 is not used at runtime by this service (the only direct usage was
+        		     removed in #132); exclude the transitive DynamoDB SDK so it is not bundled in
+        		     the fat jar. This cascades to aws-java-sdk-s3/kms/core and jmespath-java. -->
+        		<exclusion>
+        			<groupId>com.amazonaws</groupId>
+        			<artifactId>aws-java-sdk-dynamodb</artifactId>
         		</exclusion>
         	</exclusions>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.5.0</version>
+        <version>2.7.18</version>
     </parent>
 
     <properties>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,5 +1,9 @@
 server.port=5000
 
+# Spring Boot 2.6+ defaults to PATH_PATTERN_PARSER, which fails at startup with
+# Springfox 3.0.0. Keep the legacy AntPathMatcher so Swagger/Springfox loads.
+spring.mvc.pathmatch.matching-strategy=ANT_PATH_MATCHER
+
 # Logging goes to stdout/console only (see logback-spring.xml) so it is collected
 # into CloudWatch from the container's stdout on EKS (Fluent Bit / Container Insights).
 # File logging is intentionally NOT configured: an in-container log file is ephemeral

--- a/src/test/java/reciter/pubmed/retriever/PubMedArticleRetrievalServiceTest.java
+++ b/src/test/java/reciter/pubmed/retriever/PubMedArticleRetrievalServiceTest.java
@@ -1,0 +1,191 @@
+package reciter.pubmed.retriever;
+
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+
+import java.io.IOException;
+import java.util.List;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import reciter.model.pubmed.PubMedArticle;
+import reciter.pubmed.model.PubmedESearchResult;
+
+/**
+ * Unit coverage for the two pieces of load-bearing retrieval logic that previously had no tests:
+ * the query-drop detector ({@link PubMedArticleRetrievalService#isPubMedQueryDropped(JsonNode, String)})
+ * and the {@code RETRIEVAL_THRESHOLD} gate inside {@link PubMedArticleRetrievalService#retrieve(String)}.
+ *
+ * <p>These tests are pure unit tests: the query-drop cases build {@link JsonNode} inputs from JSON
+ * string literals mirroring real NCBI ESearch responses, and the threshold cases use a Mockito spy
+ * to stub {@code getNumberOfPubMedArticles} so no network call is made.
+ */
+public class PubMedArticleRetrievalServiceTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private JsonNode esearch(String json) throws IOException {
+        // Real ESearch JSON wraps everything under "esearchresult"; isPubMedQueryDropped is handed
+        // that inner node (see executeESearch), so unwrap it here.
+        return MAPPER.readTree(json).get("esearchresult");
+    }
+
+    // ---------------------------------------------------------------------
+    // isPubMedQueryDropped — query-drop detection (Fix #24 / #110 / #135)
+    // ---------------------------------------------------------------------
+
+    /**
+     * phrasenotfound present AND the remaining querytranslation is trivial (a single initial
+     * with field tag, which strips to <=2 chars) => the query was dropped, return true.
+     */
+    @Test
+    public void testQueryDropped_phraseNotFoundAndTrivialTranslation() throws Exception {
+        JsonNode node = esearch(
+                "{\"esearchresult\":{"
+                        + "\"count\":\"500000\","
+                        + "\"querytranslation\":\"J[Author]\","
+                        + "\"errorlist\":{\"phrasenotfound\":[\"Charles-rawlins[Author]\"]}"
+                        + "}}");
+        assertTrue(PubMedArticleRetrievalService.isPubMedQueryDropped(node, "Charles-rawlins J[au]"),
+                "Dropped phrase leaving a trivial single-initial translation must be detected as dropped");
+    }
+
+    /**
+     * phrasenotfound present but the remaining querytranslation is substantial (a real surname) =>
+     * not a drop we should neutralize, return false.
+     */
+    @Test
+    public void testQueryNotDropped_phraseNotFoundButSubstantialTranslation() throws Exception {
+        JsonNode node = esearch(
+                "{\"esearchresult\":{"
+                        + "\"count\":\"42\","
+                        + "\"querytranslation\":\"Kukafka[Author] AND R[Author]\","
+                        + "\"errorlist\":{\"phrasenotfound\":[\"somedroppedterm[Author]\"]}"
+                        + "}}");
+        assertFalse(PubMedArticleRetrievalService.isPubMedQueryDropped(node, "Kukafka R somedroppedterm[au]"),
+                "A substantial remaining translation must NOT be treated as a dropped query");
+    }
+
+    /**
+     * No errorlist/phrasenotfound at all => nothing was dropped, return false even when the
+     * translation itself is short.
+     */
+    @Test
+    public void testQueryNotDropped_noErrorList() throws Exception {
+        JsonNode node = esearch(
+                "{\"esearchresult\":{"
+                        + "\"count\":\"3\","
+                        + "\"querytranslation\":\"J[Author]\""
+                        + "}}");
+        assertFalse(PubMedArticleRetrievalService.isPubMedQueryDropped(node, "J[au]"),
+                "Without a phrasenotfound signal no query is considered dropped");
+    }
+
+    /**
+     * errorlist present but phrasenotfound is an empty array => no phrases dropped, return false.
+     */
+    @Test
+    public void testQueryNotDropped_emptyPhraseNotFoundArray() throws Exception {
+        JsonNode node = esearch(
+                "{\"esearchresult\":{"
+                        + "\"count\":\"3\","
+                        + "\"querytranslation\":\"J[Author]\","
+                        + "\"errorlist\":{\"phrasenotfound\":[]}"
+                        + "}}");
+        assertFalse(PubMedArticleRetrievalService.isPubMedQueryDropped(node, "J[au]"),
+                "An empty phrasenotfound array means nothing was dropped");
+    }
+
+    /**
+     * phrasenotfound present and the remaining translation is only boolean operators / field tags /
+     * punctuation, which all strip away to an empty string (<=2 chars) => detected as dropped.
+     */
+    @Test
+    public void testQueryDropped_translationStripsToEmpty() throws Exception {
+        JsonNode node = esearch(
+                "{\"esearchresult\":{"
+                        + "\"count\":\"900000\","
+                        + "\"querytranslation\":\"(J[Author]) AND (B[au])\","
+                        + "\"errorlist\":{\"phrasenotfound\":[\"smith-jones[Author]\"]}"
+                        + "}}");
+        assertTrue(PubMedArticleRetrievalService.isPubMedQueryDropped(node, "Smith-Jones JB[au]"),
+                "A translation consisting only of single initials, operators and punctuation strips to <=2 chars and is a drop");
+    }
+
+    // ---------------------------------------------------------------------
+    // RETRIEVAL_THRESHOLD gate in retrieve(String)
+    // ---------------------------------------------------------------------
+
+    /**
+     * When the ESearch count exceeds RETRIEVAL_THRESHOLD (2000), retrieve() must hard-refuse with an
+     * IOException whose message is matched downstream by GlobalExceptionHandler. The spy stubs the
+     * count so no network call is performed.
+     */
+    @Test
+    public void testRetrieveThrowsWhenCountExceedsThreshold() throws Exception {
+        PubMedArticleRetrievalService service = spy(new PubMedArticleRetrievalService());
+        PubmedESearchResult result = new PubmedESearchResult();
+        result.setCount(2001);
+        doReturn(result).when(service).getNumberOfPubMedArticles("broad[au]");
+
+        try {
+            service.retrieve("broad[au]");
+            fail("Expected IOException when article count exceeds the retrieval threshold");
+        } catch (IOException e) {
+            assertEquals(e.getMessage(),
+                    "Number of PubMed Articles retrieved 2001 exceeded the threshold level 2000",
+                    "Threshold-exceeded message must match the exact text GlobalExceptionHandler keys on");
+        }
+    }
+
+    /**
+     * A boundary check: a count exactly at the threshold (2000) is NOT refused — the gate is a
+     * strict greater-than. Stubbing webenv to null short-circuits the (un-mocked) EFetch path...
+     * but to keep this a pure unit test with no network, we only assert that the threshold branch
+     * is not taken, i.e. no IOException with the threshold message is thrown for count == 2000.
+     */
+    @Test
+    public void testRetrieveDoesNotThrowAtExactThreshold() throws Exception {
+        PubMedArticleRetrievalService service = spy(new PubMedArticleRetrievalService());
+        PubmedESearchResult result = new PubmedESearchResult();
+        result.setCount(2000);
+        doReturn(result).when(service).getNumberOfPubMedArticles("exactly2000[au]");
+
+        try {
+            service.retrieve("exactly2000[au]");
+            fail("Expected the EFetch path (not the threshold refusal) to be exercised for count == 2000");
+        } catch (IOException e) {
+            // Count 2000 must NOT trip the threshold gate; any IOException here comes from the
+            // downstream EFetch attempt (no HTTP client wired in this unit test), never the gate.
+            assertFalse(e.getMessage() != null
+                            && e.getMessage().startsWith("Number of PubMed Articles retrieved"),
+                    "Count equal to the threshold must not be refused by the threshold gate");
+        }
+    }
+
+    /**
+     * A zero-count ESearch returns an empty list immediately with no EFetch round-trip. Because the
+     * count==0 branch returns before any HTTP client is touched, this runs as a pure unit test even
+     * though no CloseableHttpClient is wired into the service.
+     */
+    @Test
+    public void testRetrieveReturnsEmptyForZeroCount() throws Exception {
+        PubMedArticleRetrievalService service = spy(new PubMedArticleRetrievalService());
+        PubmedESearchResult result = new PubmedESearchResult();
+        result.setCount(0);
+        doReturn(result).when(service).getNumberOfPubMedArticles("nomatch[au]");
+
+        List<PubMedArticle> articles = service.retrieve("nomatch[au]");
+        assertNotNull(articles, "A zero-count query must return a non-null list");
+        assertTrue(articles.isEmpty(), "A zero-count query must return an empty list with no EFetch");
+    }
+}


### PR DESCRIPTION
## dev → master promotion (full catch-up)

Carries the validated `dev` bundle to `master` so the (now-fixed) prod pipeline can deploy current code. **Prod has been on the July-2025 build (`c73d349`) for ~11 months** because the CodeBuild deploy was broken; this is the catch-up.

### Included (all merged to dev, CI-green individually and combined)
- **#147** — modernized CodeBuild buildspecs (corretto11, kubectl, ECR login v2) for the new image `amazonlinux2-x86_64-standard:5.0` that fixes the broken build/deploy.
- **#146 / #113** — Spring Boot 2.5.0 → 2.7.18 (stays on javax) + Springfox `ANT_PATH_MATCHER` fix. Runtime-verified.
- **#144 / #119** — exclude transitive AWS SDK + Jackson→2.12.7.1 + TestNG→7.5.1 (clears the 5 Dependabot highs; supersedes #91).
- **#142 / #122** — query-drop + threshold unit tests; run unit tests in the buildspecs.
- (already on master from earlier today: #137 exception handler/Squiggly, #143/#145 DOCTYPE hotfix, #139/#140/#141 cleanup.)

### Validation
- Combined `dev` HEAD `7b1fada`: GitHub Actions `build` ✅ (compiles + unit tests pass together).
- Deploy pipeline proven on **dev**: `reciter-pubmed-dev` rolled to the new image, pod healthy.
- Recommended before merge: approve the Dev pipeline run for `7b1fada` to boot the *combined* bundle in-cluster.

### After merge
Run + approve the `…-prod` CodePipeline to deploy `master` to prod (the ~11-month catch-up). AWS CodeBuild PR check remains pre-existing-red is N/A now — the project image is fixed.