### PR TITLE
Drop explicit Jackson pins; let Spring Boot 2.7 BOM manage Jackson

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,25 +34,9 @@
             <artifactId>squiggly-filter-jackson</artifactId>
             <version>1.3.18</version>
         </dependency>
-        <!-- Jackson pinned to the latest patched 2.12.x to clear known CVEs while staying on the
-             2.12 line (binary-compatible with Spring Boot 2.5's managed Jackson). databind 2.12.7.1
-             is the security hotfix on top of the 2.12.7 core/annotations. -->
-        <!-- https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-annotations -->
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-annotations</artifactId>
-            <version>2.12.7</version>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-core</artifactId>
-            <version>2.12.7</version>
-        </dependency>
-        <dependency>
-		    <groupId>com.fasterxml.jackson.core</groupId>
-		    <artifactId>jackson-databind</artifactId>
-		    <version>2.12.7.1</version>
-		</dependency>
+        <!-- Jackson is managed by the Spring Boot 2.7 BOM (currently 2.13.x), which supersedes the
+             explicit 2.12.x CVE pins that were required under Boot 2.5. Do not re-pin Jackson here:
+             bump Spring Boot to move Jackson, so the whole stack stays version-aligned. -->
         <dependency>
 			<groupId>io.springfox</groupId>
 			<artifactId>springfox-boot-starter</artifactId>


### PR DESCRIPTION
Follow-up cleanup to #146 (Spring Boot 2.5 → 2.7.18).

### What
Removes the explicit `jackson-annotations`/`jackson-core` `2.12.7` and `jackson-databind` `2.12.7.1` dependency pins from `pom.xml`. A comment replaces them so they aren't re-added.

### Why
Those pins were introduced under Boot 2.5 to backport Jackson CVE fixes onto the 2.12 line. Boot **2.7.18** manages Jackson **2.13.5** through its BOM, which already includes those fixes. With the explicit pins in place, the direct dependencies *override* the BOM and hold Jackson back at 2.12.x — so the pins now only cause a downgrade. Dropping them lets the whole stack stay version-aligned with the Spring Boot BOM.

### Verification (local, JDK 11)
- `mvn clean package` — **BUILD SUCCESS**
- Resolved/bundled Jackson is now **2.13.5** (`jackson-core/databind/annotations`), confirmed via the repackaged fat jar — ≥ the previously-pinned 2.12.7.1, so no CVE regression.
- `mvn test -Dtest=PubmedEFetchHandlerTest,PubMedUriParserCallableTest,PubMedArticleRetrievalServiceTest` — **15/15 pass**
- Runtime: booted the jar on :8083 and ran a live query (`/pubmed/query/Kukafka R[au]`) → 120 articles, valid JSON (jq-validated), and the squiggly `?fields=…` filter narrows the payload correctly. This exercises the live serialization path that unit tests don't cover.

No functional change; dependency hygiene only.