### PR TITLE
docs: deploy/approval runbook + issue #117 rate-limiter design doc

### DIFF
--- a/docs/deploy-and-approval-runbook.md
+++ b/docs/deploy-and-approval-runbook.md
@@ -1,0 +1,428 @@
+# Deploy & Approval Runbook — ReCiter-PubMed-Retrieval-Tool
+
+A durable how-to for building, deploying, and approving releases of the
+ReCiter-PubMed-Retrieval-Tool Spring Boot microservice to EKS via AWS CodeBuild /
+CodePipeline. This is an operational runbook, not an incident report. Read it before
+touching the pipeline, the `PubMedService` CodeBuild project, or either buildspec.
+
+> Conventions in this doc:
+> - "confirmed" = verified against a repo file or a live `aws` CLI call on 2026-06-13.
+> - "as configured" = asserted from project memory / prior sessions but not re-verified
+>   from a file or the API in this writing; treat these as facts to re-check (they are
+>   listed in the handoff `keyClaims`).
+> - Region is `us-east-1` throughout. Account `665083158573` (IAM user `reciter`).
+
+---
+
+## 1. Architecture
+
+### Build & deploy system
+
+A single AWS **CodeBuild project named `PubMedService`** builds the service and
+deploys it to the EKS cluster. Confirmed live configuration:
+
+| Property | Value | Source |
+|----------|-------|--------|
+| CodeBuild project name | `PubMedService` | `aws codebuild batch-get-projects` |
+| Image | `aws/codebuild/amazonlinux2-x86_64-standard:5.0` | confirmed live |
+| Compute type | `BUILD_GENERAL1_SMALL` | confirmed live |
+| Environment type | `LINUX_CONTAINER` | confirmed live |
+| Source type | `GITHUB` (`wcmc-its/ReCiter-PubMed-Retrieval-Tool`) | confirmed live |
+| Buildspec | `k8-buildspec.yml` | confirmed live |
+| Buildspec runtime | `java: corretto11` | `k8-buildspec.yml` line 6 |
+
+The same `PubMedService` project is driven by **both** the Dev and prod pipelines.
+The pipeline injects a `BRANCH` environment variable (`#{SourceVariables.BranchName}`)
+that the buildspec uses to decide which environment to target (`dev` vs `master`).
+
+### Two buildspecs
+
+| File | Purpose | Status |
+|------|---------|--------|
+| `buildspec.yml` | Legacy Elastic Beanstalk packaging (artifacts: jar + `.ebextensions` + `Procfile`) | retained, **not** the EKS path |
+| `k8-buildspec.yml` | Kubernetes / EKS build + image push + `kubectl set image` deploy | **active** path used by `PubMedService` |
+
+The EKS deploy uses `k8-buildspec.yml`. `buildspec.yml` is kept for the legacy
+Beanstalk flow and as a minimal compile/test definition; do not delete it without
+confirming nothing references it.
+
+### Curated tests — load test is NEVER run
+
+Both buildspecs run a curated subset of unit tests and deliberately exclude the live
+load tests:
+
+```bash
+mvn clean install \
+  -Dtest=PubmedEFetchHandlerTest,PubMedUriParserCallableTest,PubMedArticleRetrievalServiceTest \
+  -DfailIfNoTests=false
+```
+
+(`buildspec.yml` line 17; `k8-buildspec.yml` line 50.)
+
+The load tests `ReCiterPubmedApiLoadTest` / `LoadTest` are **never** executed in CI:
+they make live HTTP calls to a running service and return **403 Forbidden** when no
+service is up. Do not add them to the `-Dtest` list and do not remove the
+`-Dtest=` filter (which would run the whole suite, including the load tests).
+
+> Runtime-verification gap: the curated unit tests parse local fixtures with no
+> DOCTYPE, and the load test is skipped, so neither catches live-path regressions in
+> the SAX parser / HTTP client. For changes touching the parser, HTTP client, deps,
+> or the Boot version, **boot the jar and run a real query** (see Section 7).
+
+### CodeBuild environment variables — MUST be preserved
+
+The `PubMedService` project relies on exactly four environment variables. Confirmed
+present live:
+
+- `REPOSITORY_URI` — ECR repo URI for the image (`<acct>.dkr.ecr.us-east-1.amazonaws.com/<repo>`)
+- `EKS_KUBECTL_ROLE_ARN` — IAM role assumed to run `kubectl` against the cluster
+- `EKS_CLUSTER_NAME` — EKS cluster name (also used as the kubectl `-n` namespace in the buildspec)
+- `DOCKER_HUB_CREDENTIALS_ARN` — Secrets Manager ARN for Docker Hub login (avoids anonymous pull rate limits)
+
+**Critical:** `aws codebuild update-project --environment` **REPLACES the entire
+environment block**. Any update that passes `--environment` must re-list all four
+variables or they will be silently dropped, breaking the deploy. See Section 4(c).
+
+### Runtime topology (what gets deployed)
+
+- EKS cluster `reciter`, namespace `reciter` *(as configured)*.
+- Deployments: **`reciter-pubmed-dev`** and **`reciter-pubmed-prod`** (rendered from
+  `kubernetes/k8-deployment.yaml` via `sed` token substitution in the buildspec).
+- Each pod is **2 containers**: the app (`reciter-pubmed`, port 5000) and an `nginx`
+  sidecar (port 80) that reverse-proxies `/pubmed/*` to `localhost:5000`. A healthy
+  rolled pod therefore shows **`2/2` Ready**.
+- App container runs as non-root UID/GID `10001`, `JAVA_OPTIONS=-Xmx2000m`,
+  `PUBMED_API_KEY` from secret `pubmed-secret`, `SERVER_PORT` from configmap
+  `env-config-dev` / `env-config-prod`.
+- Health endpoint: `GET /pubmed/ping` → `Healthy` (used by liveness/readiness probes
+  on port 5000; nginx liveness/readiness use `/nginx-health` on port 80).
+- HPA: `hpa-reciter-pubmed-dev` / `hpa-reciter-pubmed-prod`, min 1 / max 4 replicas,
+  CPU 80% / memory 85% targets.
+- Nodes: `nodeSelector: lifecycle: Ec2Spot`.
+
+---
+
+## 2. Pipeline flow
+
+Both pipelines have the **same three-stage shape** (confirmed live):
+`Source → ManualApproval → Build`. There is **no separate CodePipeline Deploy
+stage** — the deploy is performed inside the CodeBuild `Build` stage by the buildspec
+(`docker push` + `aws eks update-kubeconfig` + `kubectl set image`). Approval gates
+the **build+deploy**, not a downstream deploy action.
+
+### Dev flow
+
+Pipeline: **`ReCiter-Pubmed-Retrieval-Tool-Dev`** (Source branch `dev`, confirmed).
+
+```
+push / merge to `dev`
+  → CodePipeline Source (GitHub, branch dev)
+  → ManualApproval gate            (agent/user may approve dev)
+  → Build (CodeBuild PubMedService, BRANCH=dev)
+        mvn curated tests → docker build/push $REPOSITORY_URI:dev-<n>...
+        aws eks update-kubeconfig --role-arn $EKS_KUBECTL_ROLE_ARN
+        kubectl set image deployment/reciter-pubmed-dev reciter-pubmed=$REPOSITORY_URI:<tag> -n $EKS_CLUSTER_NAME
+  → verify: pod reciter-pubmed-dev rolled, 2/2 Ready, /pubmed/ping = Healthy
+```
+
+Dev approvals are routine and may be approved by the agent or user.
+
+Verify a dev rollout:
+
+```bash
+aws eks update-kubeconfig --name reciter --region us-east-1   # or assume EKS_KUBECTL_ROLE_ARN
+kubectl -n reciter rollout status deployment/reciter-pubmed-dev
+kubectl -n reciter get pods -l app=reciter-pubmed-dev          # expect 2/2 Ready
+kubectl -n reciter get deployment reciter-pubmed-dev \
+  -o jsonpath='{.spec.template.spec.containers[0].image}{"\n"}'   # confirm new tag
+```
+
+> A second, parallel dev pipeline `ReCiter-Pubmed-Retrieval-Tool-Dev_V2` also exists
+> (confirmed in `list-pipelines`). Confirm which dev pipeline is the live one before
+> approving — do not approve both for the same change.
+
+### Prod flow
+
+Pipeline: **`ReCiter-Pubmed-Retrieval-Tool-prod`** (Source branch `master`, confirmed).
+
+```
+merge to `master`
+  → CodePipeline Source (GitHub, branch master)
+  → ManualApproval gate            (NON-hotfix: mrj4001 only — see Section 3)
+  → Build (CodeBuild PubMedService, BRANCH=master)
+        mvn curated tests → docker build/push $REPOSITORY_URI:master-<n>...
+        kubectl set image deployment/reciter-pubmed-prod reciter-pubmed=$REPOSITORY_URI:<tag> -n $EKS_CLUSTER_NAME
+  → verify: pod reciter-pubmed-prod rolled, 2/2 Ready
+```
+
+Verify a prod rollout (swap `dev`→`prod` in the dev commands above):
+
+```bash
+kubectl -n reciter rollout status deployment/reciter-pubmed-prod
+kubectl -n reciter get pods -l app=reciter-pubmed-prod          # expect 2/2 Ready
+kubectl -n reciter get deployment reciter-pubmed-prod \
+  -o jsonpath='{.spec.template.spec.containers[0].image}{"\n"}'
+```
+
+---
+
+## 3. Approval policy
+
+**Non-hotfix production deploys MUST be approved by `mrj4001`** at the
+`ReCiter-Pubmed-Retrieval-Tool-prod` ManualApproval gate. The agent and the requesting
+user (`paa2013`) must **not** rubber-stamp routine or catch-up prod releases — leave
+the gate pending and hand off / notify `mrj4001`.
+
+**Hotfixes are the carve-out** and may be fast-tracked (approved promptly by
+agent/user) — e.g. a live-outage fix such as the EFetch DOCTYPE-parsing hotfix. Use
+judgment: a "hotfix" is a narrowly-scoped fix for an active production defect, not a
+bundle of accumulated changes.
+
+**Dev approvals** are routine and may be approved by the agent/user.
+
+### Notification channel
+
+The approval gate notifies the SNS topic **`reciter-pipeline-validation`**
+(`arn:aws:sns:us-east-1:665083158573:reciter-pipeline-validation`, confirmed).
+
+Current email subscribers (confirmed live, 2026-06-13):
+
+| Endpoint | Protocol |
+|----------|----------|
+| `paa2013@med.cornell.edu` | email |
+| `szd2013@med.cornell.edu` | email |
+
+> **ENABLEMENT GAP (action item, not a permanent fact):** `mrj4001` is **not** yet a
+> subscriber of `reciter-pipeline-validation`, yet policy requires them to approve
+> non-hotfix prod deploys. To close the gap, `mrj4001` needs:
+> 1. an **email subscription** to the topic, and
+> 2. console **`codepipeline:PutApprovalResult`** access (federated/SSO — `mrj4001`
+>    is a CWID, not an IAM user) *(as configured)*.
+>
+> Subscribe (then `mrj4001` must click the confirmation email):
+> ```bash
+> aws sns subscribe \
+>   --topic-arn arn:aws:sns:us-east-1:665083158573:reciter-pipeline-validation \
+>   --protocol email \
+>   --notification-endpoint mrj4001@med.cornell.edu
+> ```
+> Until this is done, `mrj4001` will not receive gate notifications; coordinate the
+> hand-off out of band.
+
+---
+
+## 4. Gotchas (read before approving or editing the project)
+
+### (a) Stale executions pile up at the ManualApproval gate
+
+Because approvals are manual and several executions can queue (e.g. a superseded
+older build still holding a token), **the token surfaced at the gate may not belong
+to the execution you want to deploy.** Approving a stale token returns an `approvedAt`
+timestamp but does **not** advance the latest revision.
+
+Always map **approval token → execution → revision** before acting, and **reject**
+stale gate-holders so the latest can advance.
+
+```bash
+PIPE=ReCiter-Pubmed-Retrieval-Tool-prod
+
+# What is sitting at the gate right now (token + which execution holds it)?
+aws codepipeline get-pipeline-state --name "$PIPE" \
+  --query 'stageStates[?stageName==`ManualApproval`].actionStates[0].latestExecution' \
+  --output json
+
+# Map that execution to its source revision (commit) so you know what you'd ship.
+aws codepipeline list-pipeline-executions --pipeline-name "$PIPE" \
+  --max-items 10 \
+  --query 'pipelineExecutionSummaries[*].{id:pipelineExecutionId,status:status,rev:sourceRevisions[0].revisionId,summary:sourceRevisions[0].revisionSummary}' \
+  --output table
+```
+
+Reject a stale holder so a newer execution can take the gate:
+
+```bash
+aws codepipeline put-approval-result \
+  --pipeline-name "$PIPE" \
+  --stage-name ManualApproval \
+  --action-name ManualApproval \
+  --token <STALE_TOKEN> \
+  --result status=Rejected,summary='superseded by newer execution'
+```
+
+### (b) `put-approval-result --result` shorthand breaks on a comma in `summary=`
+
+The CLI shorthand parses `key=value,key=value`, so a **comma inside the `summary`
+text** is read as a new key and the call fails. Either omit commas, or pass the
+result as JSON.
+
+Broken (comma inside summary):
+```bash
+# FAILS — the comma after "approved" is parsed as a field separator
+--result status=Approved,summary='approved, deploying master'
+```
+
+Works (no comma):
+```bash
+--result status=Approved,summary='approved deploying master'
+```
+
+Works (JSON form — safe with commas/quotes):
+```bash
+aws codepipeline put-approval-result \
+  --pipeline-name ReCiter-Pubmed-Retrieval-Tool-prod \
+  --stage-name ManualApproval \
+  --action-name ManualApproval \
+  --token <LIVE_TOKEN> \
+  --result '{"status":"Approved","summary":"approved by mrj4001, master catch-up"}'
+```
+
+### (c) `update-project --environment` REPLACES the whole environment block
+
+Any `aws codebuild update-project` that touches `--environment` must re-list **all
+four** env vars (`REPOSITORY_URI`, `EKS_KUBECTL_ROLE_ARN`, `EKS_CLUSTER_NAME`,
+`DOCKER_HUB_CREDENTIALS_ARN`) or they are dropped and the deploy breaks. Read the
+current values first, change only what you intend, and write them all back.
+
+```bash
+# 1. Dump the current environment so you don't lose anything.
+aws codebuild batch-get-projects --names PubMedService \
+  --query 'projects[0].environment' --output json
+
+# 2. Re-apply ALL four env vars even when you are only changing the image.
+aws codebuild update-project --name PubMedService --environment '{
+  "type": "LINUX_CONTAINER",
+  "image": "aws/codebuild/amazonlinux2-x86_64-standard:5.0",
+  "computeType": "BUILD_GENERAL1_SMALL",
+  "privilegedMode": true,
+  "environmentVariables": [
+    {"name":"REPOSITORY_URI",            "value":"<value>", "type":"PLAINTEXT"},
+    {"name":"EKS_KUBECTL_ROLE_ARN",      "value":"<value>", "type":"PLAINTEXT"},
+    {"name":"EKS_CLUSTER_NAME",          "value":"<value>", "type":"PLAINTEXT"},
+    {"name":"DOCKER_HUB_CREDENTIALS_ARN","value":"<value>", "type":"PLAINTEXT"}
+  ]
+}'
+
+# 3. Verify all four survived.
+aws codebuild batch-get-projects --names PubMedService \
+  --query 'projects[0].environment.environmentVariables[*].name' --output json
+```
+
+> `privilegedMode: true` is required because the buildspec runs `docker build`/`docker
+> push` (confirmed live via `aws codebuild batch-get-projects --names PubMedService` on
+> 2026-06-13).
+
+### (d) Any buildspec edit must keep three things
+
+When editing `buildspec.yml` or `k8-buildspec.yml`, preserve all of:
+
+1. **`runtime-versions: java: corretto11`** — the AL2 `standard:5.0` image's TLS
+   truststore + corretto11 resolves Maven Central; do not revert to `openjdk11` or an
+   older image.
+2. **An explicit `kubectl` install** — modern CodeBuild images do **not** bundle
+   `kubectl`. `k8-buildspec.yml` pins it:
+   ```yaml
+   - curl -sSLo /usr/local/bin/kubectl https://dl.k8s.io/release/v1.29.10/bin/linux/amd64/kubectl
+   - chmod +x /usr/local/bin/kubectl
+   - kubectl version --client      # note: no --short (removed in modern kubectl)
+   ```
+3. **`aws ecr get-login-password`** for the ECR login — AWS CLI v2 removed
+   `aws ecr get-login`:
+   ```yaml
+   - aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin ${REPOSITORY_URI%%/*}
+   ```
+
+Also keep the curated `-Dtest=...` filter (Section 1) so the load tests never run.
+
+---
+
+## 5. Background — why the image and runtime matter
+
+From roughly **July 2025 until 2026-06**, the prod deploy was **silently dead**. The
+`PubMedService` CodeBuild project ran on the deprecated **`aws/codebuild/standard:3.0`**
+image (Ubuntu 18.04, EOL). Its outdated TLS truststore could not authenticate to
+Maven Central, so `mvn clean install` failed with `Could not transfer artifact ...
+peer not authenticated` and the build exited non-zero. This was the long-standing
+"always-red AWS CodeBuild (PubMedService)" check on every `master` PR. Local builds
+(modern JDK 11 + cached `~/.m2`) succeeded, which masked the breakage.
+
+Consequence: live prod ran image tag
+`master-374.2025-07-03.04.48.11.c73d3492` — **July 2025 (commit `c73d349`)** *(as
+configured)* — so ~11 months of merges were undeployed.
+
+**Fix (2026-06):** the project image was switched to **`aws/codebuild/amazonlinux2-x86_64-standard:5.0`**
+(confirmed live) and the buildspecs were modernized in **PR #147** (`openjdk11` →
+`corretto11`, explicit pinned `kubectl` install, `aws ecr get-login` →
+`aws ecr get-login-password`). Dev was validated end-to-end (first successful deploy in
+~11 months); the prod catch-up was the deliberate follow-up gated on `mrj4001`.
+
+Takeaway for operators: **never downgrade the CodeBuild image or the buildspec
+runtime.** A green local build is not evidence the pipeline builds — verify the
+CodeBuild run itself (Section 6).
+
+---
+
+## 6. IaC caveat — the pipeline is NOT in CDK
+
+The deploy pipeline and the `PubMedService` CodeBuild project are **not** modeled by
+the current ReCiter-CDK. As configured, only the **ACM / ECR / S3 / RDS / Public**
+stacks are actually deployed from CDK; the CDK additionally models a **Fargate**
+architecture that is **not in use** (prod runs on EKS, not Fargate).
+
+Practical implications:
+
+- Make pipeline / CodeBuild changes via **AWS CLI or the console**, not by editing
+  CDK and running `cdk deploy`. A CDK deploy will not touch `PubMedService` and could
+  drift the Fargate model further from reality.
+- Because there is no IaC source of truth for these resources, **dump-before-edit**
+  (Section 4c) and re-verify after every change.
+- Record any manual change (image, env vars, buildspec branch logic) in project
+  memory so the next operator knows the live state.
+
+---
+
+## 7. Runtime verification (do this for parser / HTTP / deps / Boot changes)
+
+A build can be fully green while the live retrieval path is 100% broken (the EFetch
+DOCTYPE regression is the canonical example: every real NCBI EFetch response begins
+with `<!DOCTYPE PubmedArticleSet PUBLIC ...>`, which a DOCTYPE-disallowing SAX parser
+rejected → HTTP 500 on every query, with all unit tests still passing). For any change
+touching the SAX parser, HTTP client, dependencies, or the Spring Boot version,
+**runtime-verify** before approving a deploy.
+
+Local (JDK 11 required — Lombok 1.18.34 does not run on JDK 17+):
+
+```bash
+export JAVA_HOME=/opt/homebrew/opt/openjdk@11/libexec/openjdk.jdk/Contents/Home
+export PUBMED_API_KEY=<key>
+mvn -B -ntp clean package -DskipTests
+java -jar target/reciter-pubmed-retrieval-tool-1.1.0.jar --server.port=8083 &
+# Expect HTTP 200 with parsed articles (NOT a 500):
+curl -s 'http://localhost:8083/pubmed/ping'                       # -> Healthy
+curl -s 'http://localhost:8083/pubmed/query/Kukafka%20R%5Bau%5D' | head -c 400
+```
+
+Post-deploy (in-cluster), confirm a real query against the rolled pod, not just
+`/pubmed/ping`:
+
+```bash
+kubectl -n reciter exec deploy/reciter-pubmed-dev -c reciter-pubmed -- \
+  wget -qO- 'http://localhost:5000/pubmed/query/Kukafka%20R%5Bau%5D' | head -c 400
+```
+
+---
+
+## 8. Quick reference
+
+| Thing | Value |
+|-------|-------|
+| CodeBuild project | `PubMedService` (image `aws/codebuild/amazonlinux2-x86_64-standard:5.0`, buildspec `k8-buildspec.yml`) |
+| Dev pipeline | `ReCiter-Pubmed-Retrieval-Tool-Dev` (branch `dev`) — also `..._Dev_V2` exists |
+| Prod pipeline | `ReCiter-Pubmed-Retrieval-Tool-prod` (branch `master`) |
+| Pipeline stages | `Source → ManualApproval → Build` (Build does the deploy; no separate Deploy stage) |
+| Deployments | `reciter-pubmed-dev`, `reciter-pubmed-prod` (ns `reciter`, cluster `reciter`) |
+| Healthy pod | `2/2` (app + nginx sidecar); `GET /pubmed/ping` → `Healthy` |
+| CodeBuild env vars (preserve all 4) | `REPOSITORY_URI`, `EKS_KUBECTL_ROLE_ARN`, `EKS_CLUSTER_NAME`, `DOCKER_HUB_CREDENTIALS_ARN` |
+| Approval (non-hotfix prod) | `mrj4001` only; hotfixes fast-trackable; dev = agent/user |
+| Notification topic | `reciter-pipeline-validation` (subs: `paa2013@`, `szd2013@`; `mrj4001` NOT yet subscribed) |
+| Curated tests | `PubmedEFetchHandlerTest`, `PubMedUriParserCallableTest`, `PubMedArticleRetrievalServiceTest`; load test never run |
+| IaC | NOT in CDK — change via AWS CLI/console |

--- a/docs/rate-limiter-design-117.md
+++ b/docs/rate-limiter-design-117.md
@@ -1,0 +1,347 @@
+# Design: Shared cross-thread rate limiter and Retry-After on EFetch (Issue #117)
+
+**Status:** Design only. This document does **not** implement the change; issue #117 remains open.
+**Repo:** `wcmc-its/ReCiter-PubMed-Retrieval-Tool`
+**Runtime:** Java 11, Spring Boot 2.7.18 (`pom.xml:13,19`)
+**Scope of code reviewed:** `origin/dev` tip (worktree `docs/deploy-runbook-and-rate-limiter`, HEAD `7b1fada`).
+
+> **Important currency note.** Issue #117 was filed against `master` and cites line numbers
+> (`service:215-225`, `PubMedUriParserCallable uses raw URL.openStream()`) and a premise of
+> "high-volume EFetch **batches**." The code on `origin/dev` has since been refactored: there is
+> **no longer** an EFetch pagination loop or a work-stealing thread pool, and retrieval issues a
+> **single** EFetch per query. The *underlying gap* the issue describes (no shared rate limiter;
+> EFetch ignores rate-limit headers; per-request-only Retry-After; blocking sleep on a servlet
+> thread) is still real, just for a different concurrency reason (multiple pods + multiple
+> concurrent servlet requests, not intra-request batch fan-out). This document establishes
+> current behavior from the actual `origin/dev` code and re-frames the gap accordingly.
+
+---
+
+## 1. Current behavior (established from code)
+
+### 1.1 Retrieval flow — single EFetch, no batch fan-out, no thread pool
+
+`PubMedArticleRetrievalService.retrieve(String)` runs synchronously on the calling servlet thread:
+
+1. ESearch determines the matching count (`service:111-112`).
+2. If `count > RETRIEVAL_THRESHOLD` (2000, `service:54`) it hard-refuses with an `IOException`
+   (`service:114-116`) — mapped to HTTP 502 by `GlobalExceptionHandler` via the marker string
+   `"exceeded the threshold level"` (`GlobalExceptionHandler.java:29,34`).
+3. If `count == 0` it returns an empty list with no EFetch round-trip (`service:120-122`).
+4. Otherwise it builds **one** EFetch URL and runs **one** `PubMedUriParserCallable.call()`
+   synchronously, in-line, returning its result (`service:126-141`).
+
+The class javadoc states this explicitly: because the allowed count (2000) is well below
+`DEFAULT_RETMAX` (10000, `PubmedXmlQuery.java:11`), "every allowed query is satisfied by a single
+EFetch request — there is no need to paginate over retstart or fan the fetches out across a thread
+pool" (`service:99-105`).
+
+A repo-wide grep confirms this: there is **no** `ExecutorService`, `Executors.*`,
+`newWorkStealingPool`, `invokeAll`, or `submit(` anywhere under `src/main/java/`. The
+`PubMedUriParserCallable` still `implements Callable<...>` (`PubMedUriParserCallable.java:20`) but
+is now invoked directly via `.call()` on the servlet thread, not submitted to a pool.
+
+**Consequence for #117:** intra-request EFetch concurrency no longer exists. Concurrency that can
+collectively exceed the NCBI quota now comes from two other sources (see 1.5).
+
+### 1.2 Retry configuration (Spring `@Retryable`)
+
+`retrieve(...)` is annotated (`service:107-108`):
+
+```java
+@Retryable(maxAttempts = 7, value = IOException.class,
+    backoff = @Backoff(random = true, delay = 1500, maxDelay = 9000), listeners = {"retryListener"})
+```
+
+- **Attempts:** `maxAttempts = 7` (1 initial + 6 retries).
+- **Backoff:** randomized between `delay = 1500` ms and `maxDelay = 9000` ms per attempt
+  (`random = true`). This is the only inter-attempt wait; there is no exponential `multiplier`.
+- **Triggers on:** `IOException` only.
+- **Listener:** `RetryListener` (`RetryListener.java`) logs the retry count on each `onError`
+  (`RetryListener.java:24-27`); it does not alter backoff or honor any rate-limit signal.
+- **Recovery:** `@Recover recoverRetrieve(...)` re-throws the final `IOException` after attempts
+  are exhausted (`service:158-162`).
+- `@EnableRetry` is on `Application` (`Application.java:11`).
+
+This retry wraps the **whole** `retrieve` method (ESearch + EFetch). It reacts to thrown
+`IOException`s; it does **not** read NCBI rate-limit headers to decide its wait.
+
+### 1.3 Rate-limit / Retry-After handling — ESearch only, honored once, blocking
+
+Rate-limit handling exists **only on the ESearch path** and is invoked from `executeReadingBody`
+(`service:239-248`), which wraps the ESearch HTTP POST:
+
+```java
+try (CloseableHttpResponse response = pubMedHttpClient.execute(httppost)) {
+    if (shouldRetryAfterRateLimit(response, query)) {           // service:241
+        try (CloseableHttpResponse retryResponse = pubMedHttpClient.execute(httppost)) {
+            return readBody(retryResponse);
+        }
+    }
+    return readBody(response);
+}
+```
+
+`shouldRetryAfterRateLimit(...)` (`service:268-292`):
+
+- Reads `X-RateLimit-Limit`, `X-RateLimit-Remaining`, `Retry-After` headers (`service:269-271`),
+  fully null/length guarded because NCBI omits them on error pages.
+- Logs limit/remaining when both present (`service:273-276`).
+- If `X-RateLimit-Remaining == 0` **and** a `Retry-After` header is present, it
+  `Thread.sleep(Retry-After * 1000)` then returns `true` so the caller replays the request **once**
+  (`service:278-291`).
+
+Limitations of the current handling, all confirmed in code:
+
+- **ESearch-only.** EFetch does not call this path at all (see 1.4).
+- **Honored once.** A single replay; if the replay is also throttled the method returns the
+  throttled body (no second wait inside this method — only the outer `@Retryable` may re-enter).
+- **Blocking.** `Thread.sleep` runs on the servlet worker thread (`service:283`), tying up a Tomcat
+  thread for the full advertised interval.
+- **Per-request only.** The decision is local to one request/thread; nothing is shared across
+  threads or pods.
+
+### 1.4 EFetch fetch — raw connection, no header inspection
+
+EFetch is fetched inside `PubMedUriParserCallable.preprocessSpecialCharacters(...)`
+(`PubMedUriParserCallable.java:46-71`):
+
+```java
+URL url = new URL(inputSource.getSystemId());
+if (!EXPECTED_HOST.equalsIgnoreCase(url.getHost())) { ... }       // SSRF guard, line 50
+URLConnection connection = url.openConnection();                  // line 53
+connection.setConnectTimeout(CONNECT_TIMEOUT_MILLIS);             // 5_000, line 23/54
+connection.setReadTimeout(READ_TIMEOUT_MILLIS);                   // 60_000, line 26/55
+try (InputStream inputStream = connection.getInputStream()) {     // line 56
+    xml = new String(inputStream.readAllBytes(), StandardCharsets.UTF_8);
+}
+```
+
+- It uses a **raw `java.net.URLConnection`**, not the pooled `pubMedHttpClient`, and **never
+  inspects** `X-RateLimit-*` or `Retry-After` on the EFetch response.
+- It has an SSRF host guard (`EXPECTED_HOST = "www.ncbi.nlm.nih.gov"`,
+  `PubMedUriParserCallable.java:29,50`) and connect/read timeouts, but no throttling.
+- A 429/throttled EFetch surfaces only as an `IOException` from `getInputStream()` (e.g. HTTP 429),
+  which bubbles up to the outer `@Retryable` and is retried with the **random 1.5–9 s** backoff —
+  it does **not** read or honor the server's `Retry-After`.
+
+> The issue's phrase "PubMedUriParserCallable uses raw `URL.openStream()`" is directionally correct:
+> current code uses `url.openConnection().getInputStream()` (equivalent raw JDK fetch). The key
+> claim — EFetch ignores rate-limit headers — holds.
+
+### 1.5 Actual sources of concurrency against the shared NCBI key
+
+With batch fan-out gone, concurrent NCBI calls now come from:
+
+1. **Multiple concurrent servlet requests within one pod.** Each request runs ESearch + (up to one)
+   EFetch on its own Tomcat worker thread; the HTTP client pool allows up to
+   `MAX_TOTAL_CONNECTIONS = 50` / `MAX_CONNECTIONS_PER_ROUTE = 50` simultaneous connections to NCBI
+   (`HttpClientConfig.java:32-33`). Nothing throttles how many of those 50 fire per second.
+2. **Multiple pods.** `kubernetes/k8-deployment.yaml` defines an HPA with
+   `minReplicas: 1`, `maxReplicas: 4` (`k8-deployment.yaml:135-136`). Up to 4 pods can run
+   concurrently, each with its own 50-connection pool and its own local rate-limit view.
+3. **Other services sharing the same NCBI API key** (see 2.2).
+
+None of these coordinate. Each request, each pod, observes the per-key quota independently.
+
+---
+
+## 2. NCBI E-utilities limits
+
+> The following are NCBI's documented E-utilities policy limits, stated here as the constraint the
+> design must respect. They are not asserted from this repo's code; see the keyClaims list for the
+> verifier.
+
+- **Without an API key: 3 requests/second** per source.
+- **With an API key (`PUBMED_API_KEY`): 10 requests/second.** The key is read in
+  `PubmedXmlQuery` via `System.getenv("PUBMED_API_KEY")` (`PubmedXmlQuery.java:68`) and appended to
+  both ESearch and EFetch URLs (`PubmedXmlQuery.java:100-104,131-135`).
+- **The quota is enforced PER API KEY (or per source IP when no key is used), and is shared across
+  ALL usage of that key.** NCBI rate-limits the credential, not the process. Exceeding it returns
+  **HTTP 429** with a `Retry-After` header and `X-RateLimit-Remaining: 0`.
+
+### 2.2 The key is shared across multiple ReCiter services
+
+Per the workspace architecture, the same `PUBMED_API_KEY` is (or can be) used by more than one
+service that talks to NCBI — at minimum this PubMed Retrieval Tool, and potentially the main
+ReCiter app and the Scopus Retrieval Tool's NCBI usage. **A per-service limiter therefore cannot,
+by itself, guarantee the org stays under 10 req/s**, because it has no visibility into the other
+services' consumption of the same credential. (This cross-service sharing should be confirmed
+against actual deployment env config — see keyClaims.)
+
+---
+
+## 3. The gap (#117)
+
+| # | Gap | Evidence |
+|---|-----|----------|
+| G1 | **No shared rate limiter.** Each request/thread/pod observes the quota independently; nothing caps the aggregate request rate. | No limiter in code; `HttpClientConfig` allows 50 concurrent conns; HPA allows 4 pods. |
+| G2 | **EFetch ignores rate-limit headers entirely.** EFetch fetches via raw `URLConnection` and never reads `X-RateLimit-*` / `Retry-After`. | `PubMedUriParserCallable.java:53-58`. |
+| G3 | **Retry-After honored per-request only, and only on ESearch, only once.** | `service:241-247`, `service:268-292`. |
+| G4 | **Backoff blocks a servlet thread.** `Thread.sleep` on the Tomcat worker. | `service:283`. |
+| G5 | **`@Retryable` backoff is rate-limit-blind.** On a 429 it waits a random 1.5–9 s instead of the server-advertised `Retry-After`. | `service:107-108`. |
+| G6 | **Per-service scope may be insufficient.** The NCBI key is one budget shared across multiple services. | Section 2.2 (verify against env). |
+
+---
+
+## 4. Options
+
+All three options share a common, non-negotiable building block: **both ESearch and EFetch must
+acquire a permit before issuing their HTTP call, and both must honor a 429 `Retry-After` by
+returning that permit / suspending the limiter rather than immediately replaying.** They differ in
+*where the budget lives* and *who shares it*.
+
+### Option 1 — Per-pod in-process token bucket
+
+**Mechanism.** Add a single Spring-managed bean wrapping a token bucket — e.g. Guava
+`RateLimiter.create(permitsPerSecond)` or Resilience4j `RateLimiter` — sized to a **fraction** of
+the NCBI quota so that `pods × per-pod-rate ≤ key-quota`. With `maxReplicas: 4` and a 10 req/s key,
+each pod gets ~2 req/s (leaving headroom for other services). ESearch (`executeReadingBody`) and
+EFetch (`PubMedUriParserCallable`, which would need the bean injected instead of being a bare
+POJO) both `acquire()` before their call. On a 429, read `Retry-After` and `sleep`/`drain` the
+bucket for that interval before allowing the next acquire.
+
+**Honoring Retry-After.** Centralize the existing `shouldRetryAfterRateLimit` logic into the
+limiter: on `Remaining == 0` / 429, the limiter blocks all permit grants for `Retry-After` seconds.
+This makes EFetch honor Retry-After (closes G2/G3) and applies one coordinated wait per pod
+instead of each thread sleeping independently (mitigates, but does not eliminate, G4 — see cons).
+
+**Pros.**
+- No new infrastructure; pure in-process library. Lowest operational cost.
+- Closes G1 *within a pod*, G2, G3, G5 fully. Small, well-contained change.
+- Guava is already an indirect candidate; Resilience4j integrates cleanly with Spring Boot 2.7.
+
+**Cons / failure modes.**
+- **Does not coordinate across pods.** Correctness depends on the static fraction
+  (`per-pod-rate = key-quota / maxReplicas / safety-factor`). If the HPA scales beyond expectation,
+  or other services consume the key, the aggregate can still exceed quota (G1 partial, G6 open).
+- Static sizing wastes quota when fewer than `maxReplicas` pods are running.
+- If implemented with a blocking `acquire()`, still parks a servlet thread (G4 persists unless
+  paired with async handling; out of scope here).
+
+**Effort:** Small (~1–2 days). One bean, two call-site changes, sizing config, unit tests with a
+clock-injected limiter.
+
+### Option 2 — Shared cross-pod distributed rate limiter
+
+**Mechanism.** Put the token bucket in a store all pods share — ElastiCache **Redis** (atomic
+token-bucket via a Lua script / `bucket4j-redis`), or a **DynamoDB**-backed counter (atomic
+conditional updates on a per-second / sliding-window key). Every ESearch and EFetch acquires a
+permit from the shared bucket before calling NCBI, so all pods draw down **one** budget sized to the
+key quota (with headroom).
+
+**Honoring Retry-After.** On a 429 from NCBI, write the `Retry-After` deadline into the shared store
+(e.g. a `pausedUntil` timestamp). All pods consult it before acquiring and back off until it passes
+— so a throttle observed by *one* pod immediately throttles *all* pods. This is the only option that
+makes Retry-After genuinely cross-pod coordinated (closes G1, G2, G3, G4-coordination, G5).
+
+**Pros.**
+- True shared budget across all pods of *this service*; correct regardless of pod count.
+- Throttle signals propagate to every pod.
+
+**Cons / failure modes.**
+- **New infrastructure dependency** (ElastiCache or a DynamoDB table). Note DynamoDB SDK was
+  deliberately **excluded** from the build (`pom.xml` comment near line 92: "exclude the transitive
+  DynamoDB SDK so it is not bundled"), so DynamoDB would mean re-introducing a dependency that was
+  intentionally dropped.
+- **Per-call coordination latency** on the hot path (a Redis/Dynamo round-trip before every NCBI
+  call). For a service whose queries are small (≤2000 articles, single EFetch) this overhead may be
+  a meaningful fraction of total latency.
+- **Failure mode:** if the limiter store is unreachable, must choose fail-open (risk exceeding
+  quota) or fail-closed (block all NCBI traffic). Either is a new outage surface.
+- Still does not cover **other services** using the same key (G6 open) unless they share the same
+  store.
+
+**Effort:** Medium–Large (~1–2 weeks). New infra (CDK changes in ReCiter-CDK), client library,
+atomic-bucket logic, failure-mode policy, integration tests against a real store.
+
+### Option 3 — Org-level / per-API-key quota awareness
+
+**Mechanism.** Recognize that the unit of enforcement is the **API key**, shared across ReCiter,
+this tool, and the Scopus tool's NCBI usage. The limiter (token bucket + Retry-After pause state)
+is keyed by the API key and shared by **every** service that uses it — e.g. a shared Redis bucket
+namespaced by key, or a dedicated "NCBI gateway" service all NCBI traffic routes through that owns
+the single budget. This is Option 2 generalized to the org boundary.
+
+**Honoring Retry-After.** Identical to Option 2 but the `pausedUntil` / token state is global to the
+key, so a 429 seen by any service throttles all services using that key.
+
+**Pros.**
+- The **only** option that can actually guarantee the org stays under the NCBI per-key limit
+  (closes G6, and by extension G1 at the true boundary).
+- A single gateway centralizes Retry-After handling, logging, and key rotation.
+
+**Cons / failure modes.**
+- **Largest blast radius and coordination cost.** Requires changes/agreement across multiple repos
+  and teams; a shared gateway becomes a critical-path single point of failure for all NCBI traffic.
+- All of Option 2's infra and failure-mode concerns, amplified.
+- May be over-engineered if, in practice, this tool is the dominant consumer of the key (verify
+  actual key usage across services before committing).
+
+**Effort:** Large (multi-repo, multi-week). Cross-repo coordination (see `cross-repo` workflows),
+new shared component, ownership/on-call questions.
+
+---
+
+## 5. Comparison
+
+| Criterion | Opt 1 (per-pod bucket) | Opt 2 (cross-pod store) | Opt 3 (per-key/org) |
+|---|---|---|---|
+| Closes G1 (shared limiter) | Within a pod only | Across this service's pods | Across all services (true) |
+| Closes G2 (EFetch honors headers) | Yes | Yes | Yes |
+| Closes G3 (Retry-After cross-coordinated) | Per-pod | Cross-pod | Cross-service |
+| Handles unexpected pod scale-out | No (static fraction) | Yes | Yes |
+| Handles other services on same key | No | No | Yes |
+| New infrastructure | None | Redis or DynamoDB | Redis/gateway + multi-repo |
+| Hot-path latency cost | Negligible | Per-call round-trip | Per-call round-trip |
+| New failure surface | None | Limiter store | Gateway (critical path) |
+| Effort | Small (1–2 d) | Medium–Large (1–2 w) | Large (multi-week) |
+
+---
+
+## 6. Recommendation (phased)
+
+**Phase 0 — Unify and fix the header handling (do regardless of which budget model wins).**
+Extract the rate-limit/Retry-After logic out of `executeESearch`/`executeReadingBody` into a single
+collaborator consulted by **both** ESearch and EFetch. To do that, EFetch must first move off the
+raw `URLConnection` onto the pooled `pubMedHttpClient` (so it can read response headers) — or at
+minimum read the `URLConnection` headers it currently discards. Make `@Retryable`/the limiter honor
+the server's `Retry-After` on a 429 instead of the random 1.5–9 s backoff. This alone closes G2,
+G3, and G5 and is a prerequisite for every other phase. **Small effort; highest value-per-effort.**
+
+**Phase 1 — Ship Option 1 (per-pod in-process token bucket).** Add a Resilience4j (or Guava)
+limiter bean sized to `key-quota ÷ maxReplicas ÷ safety-factor` (e.g. 10 ÷ 4 ÷ ~1.2 ≈ 2 req/s/pod),
+made configurable via a property so it can be tuned without a rebuild. This gives correct behavior
+for the common case (≤4 pods, this tool as the main NCBI consumer) with **zero new
+infrastructure**. Document the static-sizing assumption as a known limitation.
+
+**Phase 2 — Promote to Option 2 (shared cross-pod limiter) only if measured 429s persist** after
+Phase 1, or if the service routinely runs near `maxReplicas`. Prefer **Redis/ElastiCache** over
+DynamoDB to avoid re-introducing the deliberately-excluded DynamoDB SDK. Define the fail-open vs
+fail-closed policy up front.
+
+**Phase 3 — Option 3 (org-level) only with cross-team commitment** and after confirming the actual
+distribution of NCBI key usage across services. Treat it as a coordinated multi-repo initiative, not
+a change to this repo alone. If this tool turns out to be the dominant consumer, Phase 3 may never be
+necessary.
+
+**Rationale.** The biggest correctness defect with the smallest fix is the unified Phase 0 header
+handling — it makes EFetch honor Retry-After and stops the rate-limit-blind backoff. Phase 1 then
+caps aggregate rate cheaply and correctly for the realistic deployment (HPA max 4). The expensive,
+infra-bearing options (2 and 3) are justified only by *evidence* (observed 429s, real multi-service
+contention), so they are deferred behind measurement rather than built speculatively.
+
+---
+
+## 7. Out of scope / open questions for the verifier
+
+- Confirm NCBI's current published limits (3/s no key, 10/s with key) and that the quota is
+  per-key/per-source — these are stated from policy, not from repo code.
+- Confirm whether `PUBMED_API_KEY` is actually the **same** key used by the main ReCiter app and the
+  Scopus tool in the deployed environment (determines whether G6 / Option 3 is real).
+- Async (non-blocking) request handling to fully eliminate G4 (servlet-thread blocking) is a larger
+  architectural change and is intentionally left out of this design.
+
+---
+
+*Design only — no code changed. Issue #117 stays open.*


### PR DESCRIPTION
Adds two docs under `docs/` (no code change). Facts were adversarially fact-checked against the live `origin/dev` source and live AWS state (2026-06-13).

### `docs/deploy-and-approval-runbook.md`
Durable how-to for shipping this service:
- **Architecture** — the `PubMedService` CodeBuild project (image `amazonlinux2-x86_64-standard:5.0`, `corretto11`), the two buildspecs, the curated unit tests that exclude the load test, and the four env vars that must survive any `update-project`.
- **Pipeline flow** — dev vs prod, both `Source → ManualApproval → Build` (Build *is* the deploy).
- **Approval policy** — non-hotfix prod requires `mrj4001`; SNS topic `reciter-pipeline-validation` (and the current `mrj4001`-not-subscribed enablement gap).
- **Gotchas** — stale approval tokens, the `put-approval-result` comma bug, the `update-project --environment` replace-everything trap, and the buildspec invariants.
- **Background** — the deprecated `standard:3.0` image / Maven Central TLS failure that silently killed prod deploys for ~11 months, and why the build image/runtime must stay pinned.
- **IaC caveat** — the pipeline is not in CDK (see #150).

### `docs/rate-limiter-design-117.md`
Design doc for #117 (shared cross-thread rate limiter + honor Retry-After on EFetch):
- Establishes current behavior from the code (retry config, where Retry-After / `X-RateLimit-*` are and aren't honored, real concurrency sources against the shared NCBI key).
- Compares three options — per-pod token bucket, shared cross-pod limiter, org-level per-API-key quota awareness — with pros/cons, failure modes, and effort.
- Phased recommendation. **Design only — #117 stays open.**