### PR TITLE
#117: per-pod NCBI rate limiter + honor Retry-After on EFetch

### DIFF
--- a/src/main/java/reciter/pubmed/callable/PubMedUriParserCallable.java
+++ b/src/main/java/reciter/pubmed/callable/PubMedUriParserCallable.java
@@ -4,14 +4,15 @@ import lombok.AllArgsConstructor;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 import reciter.model.pubmed.PubMedArticle;
+import reciter.pubmed.ratelimit.NcbiRateLimiter;
 import reciter.pubmed.xmlparser.PubmedEFetchHandler;
 
 import javax.xml.parsers.SAXParser;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringReader;
+import java.net.HttpURLConnection;
 import java.net.URL;
-import java.net.URLConnection;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.concurrent.Callable;
@@ -28,9 +29,14 @@ public class PubMedUriParserCallable implements Callable<List<PubMedArticle>> {
     /** Only the NCBI E-utilities host may be fetched (SSRF guard on the SAX system-id). */
     private static final String EXPECTED_HOST = "www.ncbi.nlm.nih.gov";
 
+    /** HTTP 429 (Too Many Requests) — no constant for it on {@link HttpURLConnection} in Java 11. */
+    private static final int HTTP_TOO_MANY_REQUESTS = 429;
+
     private final PubmedEFetchHandler xmlHandler;
     private final SAXParser saxParser;
     private final InputSource inputSource;
+    /** Per-pod NCBI rate limiter (issue #117). May be {@code null} in pure unit tests. */
+    private final NcbiRateLimiter rateLimiter;
 
     public List<PubMedArticle> parse(InputSource inputSource) throws SAXException, IOException {
         //inputSource = preprocessSpecialCharacters(inputSource);
@@ -50,9 +56,26 @@ public class PubMedUriParserCallable implements Callable<List<PubMedArticle>> {
             if (!EXPECTED_HOST.equalsIgnoreCase(url.getHost())) {
                 throw new IOException("Refusing to fetch EFetch XML from unexpected host: " + url.getHost());
             }
-            URLConnection connection = url.openConnection();
+            HttpURLConnection connection = (HttpURLConnection) url.openConnection();
             connection.setConnectTimeout(CONNECT_TIMEOUT_MILLIS);
             connection.setReadTimeout(READ_TIMEOUT_MILLIS);
+            // Honor the per-pod NCBI budget before issuing the EFetch request (issue #117).
+            if (rateLimiter != null) {
+                rateLimiter.acquire();
+            }
+            int status = connection.getResponseCode();
+            if (status == HTTP_TOO_MANY_REQUESTS || status == HttpURLConnection.HTTP_UNAVAILABLE) {
+                // EFetch was throttled. Read the server's Retry-After, pause the shared limiter so
+                // every other in-pod request backs off too, and surface an IOException so the
+                // outer @Retryable re-enters retrieve() (whose next acquire() waits out the pause).
+                long retryAfterSeconds = parseRetryAfterSeconds(connection.getHeaderField("Retry-After"));
+                if (rateLimiter != null) {
+                    rateLimiter.pauseFor(retryAfterSeconds);
+                }
+                connection.disconnect();
+                throw new IOException("EFetch throttled by NCBI (HTTP " + status
+                        + "), Retry-After=" + retryAfterSeconds + "s");
+            }
             try (InputStream inputStream = connection.getInputStream()) {
                 xml = new String(inputStream.readAllBytes(), StandardCharsets.UTF_8);
             }
@@ -68,5 +91,24 @@ public class PubMedUriParserCallable implements Callable<List<PubMedArticle>> {
         xml = xml.replace("<b>", "&lt;b&gt;");
         xml = xml.replace("</b>", "&lt;/b&gt;");
         return new InputSource(new StringReader(xml));
+    }
+
+    /**
+     * Parses an NCBI {@code Retry-After} header (delta-seconds form). Returns a 1-second floor when
+     * the header is absent or not an integer (NCBI uses delta-seconds, not the HTTP-date form), so a
+     * throttled response always produces some back-off rather than a tight retry loop.
+     */
+    private static long parseRetryAfterSeconds(String headerValue) {
+        if (headerValue != null) {
+            try {
+                long seconds = Long.parseLong(headerValue.trim());
+                if (seconds > 0) {
+                    return seconds;
+                }
+            } catch (NumberFormatException ignored) {
+                // Fall through to the default floor below.
+            }
+        }
+        return 1L;
     }
 }

--- a/src/main/java/reciter/pubmed/ratelimit/NcbiRateLimiter.java
+++ b/src/main/java/reciter/pubmed/ratelimit/NcbiRateLimiter.java
@@ -1,0 +1,128 @@
+package reciter.pubmed.ratelimit;
+
+import java.util.concurrent.TimeUnit;
+import java.util.function.LongSupplier;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Per-pod, in-process rate limiter for outbound NCBI E-utilities calls (issue #117, Phase 1).
+ *
+ * <p>NCBI enforces its request quota <em>per API key</em> — 10 req/s with a key, 3 req/s without —
+ * shared across every process that uses that key. With this service horizontally scaled (the HPA
+ * allows up to 4 pods) and a 50-connection HTTP pool per pod, nothing previously capped how fast
+ * the service issued NCBI requests, so concurrent servlet requests could collectively exceed the
+ * quota and earn HTTP 429s. This limiter smooths each pod to a configurable fraction of the key
+ * quota ({@code pubmed.ratelimit.permits-per-second}, default 2.0 ≈ 10/s ÷ 4 pods ÷ headroom) so
+ * the aggregate across the expected pod count stays under the per-key limit.
+ *
+ * <p>It is a single shared bean: {@link #acquire()} is called before <em>both</em> the ESearch POST
+ * and the EFetch GET, so all in-pod NCBI traffic draws from one budget. When NCBI signals throttling
+ * (HTTP 429 / {@code X-RateLimit-Remaining: 0} with a {@code Retry-After}), {@link #pauseFor(long)}
+ * suspends <em>all</em> permit grants in this pod until the advertised interval passes — so a
+ * throttle observed by one request immediately backs off every other request in the pod, instead of
+ * each thread sleeping independently.
+ *
+ * <p>This is the per-pod (Option 1) phase of {@code docs/rate-limiter-design-117.md}. Cross-pod
+ * coordination (Options 2/3) is deliberately out of scope: correctness here depends on the static
+ * sizing {@code permits-per-second ≈ key-quota ÷ maxReplicas ÷ safety-factor}.
+ */
+@Slf4j
+@Component
+public class NcbiRateLimiter {
+
+    private final boolean enabled;
+    private final long intervalNanos;     // minimum spacing between successive permits
+    private final LongSupplier nanoClock; // seam for tests; defaults to System::nanoTime
+    private final Sleeper sleeper;        // seam for tests; defaults to TimeUnit.NANOSECONDS.sleep
+
+    /** Earliest time (nanoClock domain) at which the next permit may be granted. Guarded by {@code this}. */
+    private long nextPermitNanos = Long.MIN_VALUE;
+
+    /** Indirection over the actual blocking wait so tests can run without real time passing. */
+    @FunctionalInterface
+    interface Sleeper {
+        void sleepNanos(long nanos) throws InterruptedException;
+    }
+
+    @Autowired
+    public NcbiRateLimiter(
+            @Value("${pubmed.ratelimit.permits-per-second:2.0}") double permitsPerSecond,
+            @Value("${pubmed.ratelimit.enabled:true}") boolean enabled) {
+        this(permitsPerSecond, enabled, System::nanoTime, defaultSleeper());
+    }
+
+    /** Seam constructor: inject the clock and sleeper for deterministic unit tests. */
+    NcbiRateLimiter(double permitsPerSecond, boolean enabled, LongSupplier nanoClock, Sleeper sleeper) {
+        if (permitsPerSecond <= 0) {
+            throw new IllegalArgumentException(
+                    "pubmed.ratelimit.permits-per-second must be > 0, was " + permitsPerSecond);
+        }
+        this.enabled = enabled;
+        this.nanoClock = nanoClock;
+        this.sleeper = sleeper;
+        this.intervalNanos = (long) (TimeUnit.SECONDS.toNanos(1) / permitsPerSecond);
+        if (enabled) {
+            log.info("NCBI rate limiter enabled: {} permit(s)/sec ({} ms spacing).",
+                    permitsPerSecond, TimeUnit.NANOSECONDS.toMillis(intervalNanos));
+        } else {
+            log.info("NCBI rate limiter disabled (pubmed.ratelimit.enabled=false).");
+        }
+    }
+
+    private static Sleeper defaultSleeper() {
+        return nanos -> {
+            if (nanos > 0) {
+                TimeUnit.NANOSECONDS.sleep(nanos);
+            }
+        };
+    }
+
+    /**
+     * Blocks until a permit is available — respecting both the steady-state rate and any active
+     * {@link #pauseFor(long) Retry-After pause} — then returns. A no-op when disabled. The wait is
+     * computed under the lock but performed outside it, so a sleeping caller never blocks others
+     * from reserving their own (later) slots.
+     */
+    public void acquire() {
+        if (!enabled) {
+            return;
+        }
+        long waitNanos;
+        synchronized (this) {
+            long now = nanoClock.getAsLong();
+            long grantAt = Math.max(now, nextPermitNanos);
+            waitNanos = grantAt - now;
+            nextPermitNanos = grantAt + intervalNanos;
+        }
+        if (waitNanos > 0) {
+            try {
+                sleeper.sleepNanos(waitNanos);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                log.warn("Interrupted while waiting for an NCBI rate-limit permit.", e);
+            }
+        }
+    }
+
+    /**
+     * Suspends all permit grants until at least {@code retryAfterSeconds} from now, honoring an NCBI
+     * {@code Retry-After}. Safe to call from any thread; the longest pause wins. A no-op when
+     * disabled or given a non-positive interval.
+     */
+    public synchronized void pauseFor(long retryAfterSeconds) {
+        if (!enabled || retryAfterSeconds <= 0) {
+            return;
+        }
+        long resumeAt = nanoClock.getAsLong() + TimeUnit.SECONDS.toNanos(retryAfterSeconds);
+        if (resumeAt > nextPermitNanos) {
+            nextPermitNanos = resumeAt;
+            log.warn("NCBI throttling observed; pausing all outbound NCBI requests in this pod for {}s (Retry-After).",
+                    retryAfterSeconds);
+        }
+    }
+}

--- a/src/main/java/reciter/pubmed/retriever/PubMedArticleRetrievalService.java
+++ b/src/main/java/reciter/pubmed/retriever/PubMedArticleRetrievalService.java
@@ -37,6 +37,7 @@ import reciter.model.pubmed.PubMedArticle;
 import reciter.pubmed.callable.PubMedUriParserCallable;
 import reciter.pubmed.model.PubmedESearchResult;
 import reciter.pubmed.querybuilder.PubmedXmlQuery;
+import reciter.pubmed.ratelimit.NcbiRateLimiter;
 import reciter.pubmed.xmlparser.PubmedEFetchHandler;
 
 @Slf4j
@@ -57,6 +58,10 @@ public class PubMedArticleRetrievalService {
 
     @Autowired
     private CloseableHttpClient pubMedHttpClient;
+
+    /** Per-pod NCBI rate limiter (issue #117); acquired before every ESearch and EFetch call. */
+    @Autowired
+    private NcbiRateLimiter rateLimiter;
 
     /*@Autowired
     private SAXParser saxParser;
@@ -137,7 +142,7 @@ public class PubMedArticleRetrievalService {
 
         try {
             PubMedUriParserCallable callable =
-                    new PubMedUriParserCallable(new PubmedEFetchHandler(), getSaxParser(), new InputSource(eFetchUrl));
+                    new PubMedUriParserCallable(new PubmedEFetchHandler(), getSaxParser(), new InputSource(eFetchUrl), rateLimiter);
             return new ArrayList<>(callable.call());
         } catch (IOException e) {
             throw e;
@@ -237,8 +242,12 @@ public class PubMedArticleRetrievalService {
      * Response entities are always closed via try-with-resources.
      */
     private String executeReadingBody(HttpPost httppost, String query) throws IOException {
+        rateLimiter.acquire();
         try (CloseableHttpResponse response = pubMedHttpClient.execute(httppost)) {
             if (shouldRetryAfterRateLimit(response, query)) {
+                // shouldRetryAfterRateLimit has paused the shared limiter for the advertised
+                // Retry-After; this acquire() waits it out before replaying the request once.
+                rateLimiter.acquire();
                 try (CloseableHttpResponse retryResponse = pubMedHttpClient.execute(httppost)) {
                     return readBody(retryResponse);
                 }
@@ -260,10 +269,12 @@ public class PubMedArticleRetrievalService {
     }
 
     /**
-     * Inspects the NCBI rate-limit response headers. Returns {@code true} (after sleeping for the
-     * advertised Retry-After interval) when the remaining quota is exhausted and the caller should
-     * replay the request. Header access is fully null/length guarded because NCBI omits these
-     * headers on error pages.
+     * Inspects the NCBI rate-limit response headers. When the remaining quota is exhausted
+     * (X-RateLimit-Remaining == 0) and a Retry-After header is present, it pauses the shared
+     * {@link NcbiRateLimiter} for the advertised interval — so every in-pod request backs off, not
+     * just this thread — and returns {@code true} so the caller replays the request once (its
+     * {@link NcbiRateLimiter#acquire()} waits the pause out). Header access is fully null/length
+     * guarded because NCBI omits these headers on error pages.
      */
     private boolean shouldRetryAfterRateLimit(CloseableHttpResponse response, String query) {
         Header[] headerRateLimitRemaining = response.getHeaders("X-RateLimit-Remaining");
@@ -280,10 +291,10 @@ public class PubMedArticleRetrievalService {
             if (headerRetryAfter != null && headerRetryAfter.length > 0 && headerRetryAfter[0] != null) {
                 log.info("Query=[{}] {}", query, headerRetryAfter[0].toString());
                 try {
-                    Thread.sleep(Long.parseLong(headerRetryAfter[0].getValue()) * 1000L);
-                } catch (InterruptedException e) {
-                    log.error("InterruptedException", e);
-                    Thread.currentThread().interrupt();
+                    rateLimiter.pauseFor(Long.parseLong(headerRetryAfter[0].getValue()));
+                } catch (NumberFormatException e) {
+                    log.warn("Unparseable Retry-After header value [{}] for query=[{}]; skipping pause.",
+                            headerRetryAfter[0].getValue(), query);
                 }
                 return true;
             }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -4,6 +4,14 @@ server.port=5000
 # Springfox 3.0.0. Keep the legacy AntPathMatcher so Swagger/Springfox loads.
 spring.mvc.pathmatch.matching-strategy=ANT_PATH_MATCHER
 
+# NCBI E-utilities per-pod rate limiter (issue #117). NCBI enforces its quota per API key
+# (~10 req/s with a key, 3 req/s without), shared across every process using that key. Each pod
+# is smoothed to a fraction of that budget so pods x rate stays under quota (the HPA allows up to
+# 4 pods, so ~2/s/pod leaves headroom for retries and other services on the same key). Tune these
+# without a rebuild; set pubmed.ratelimit.enabled=false to disable entirely (e.g. local dev).
+pubmed.ratelimit.permits-per-second=2.0
+pubmed.ratelimit.enabled=true
+
 # Logging goes to stdout/console only (see logback-spring.xml) so it is collected
 # into CloudWatch from the container's stdout on EKS (Fluent Bit / Container Insights).
 # File logging is intentionally NOT configured: an in-container log file is ephemeral

--- a/src/test/java/reciter/pubmed/callable/PubMedUriParserCallableTest.java
+++ b/src/test/java/reciter/pubmed/callable/PubMedUriParserCallableTest.java
@@ -5,6 +5,7 @@ import org.testng.annotations.Test;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 import reciter.model.pubmed.PubMedArticle;
+import reciter.pubmed.ratelimit.NcbiRateLimiter;
 import reciter.pubmed.xmlparser.PubmedEFetchHandler;
 
 import javax.xml.parsers.SAXParser;
@@ -37,7 +38,10 @@ public class PubMedUriParserCallableTest {
     public void testInvalidCharacterParse() throws Exception {
         File initialFile = new File("src/test/resources/reciter/pubmed/callable/28356292.xml");
         inputSource = new InputSource(new FileInputStream(initialFile));
-        pubMedUriParserCallable = new PubMedUriParserCallable(xmlHandler, saxParser, inputSource);
+        // This fixture parses a local file (systemId is null), so the rate limiter is never
+        // exercised; pass a disabled one to satisfy the constructor.
+        NcbiRateLimiter rateLimiter = new NcbiRateLimiter(2.0, false);
+        pubMedUriParserCallable = new PubMedUriParserCallable(xmlHandler, saxParser, inputSource, rateLimiter);
         List<PubMedArticle> pubMedArticles = pubMedUriParserCallable.call();
         PubMedArticle pubMedArticle = pubMedArticles.get(0);
         String articleTitle = pubMedArticle.getMedlinecitation().getArticle().getArticletitle();

--- a/src/test/java/reciter/pubmed/ratelimit/NcbiRateLimiterTest.java
+++ b/src/test/java/reciter/pubmed/ratelimit/NcbiRateLimiterTest.java
@@ -1,0 +1,106 @@
+package reciter.pubmed.ratelimit;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+/**
+ * Deterministic unit tests for {@link NcbiRateLimiter}. A fake clock and a fake sleeper (which
+ * advances that clock instead of actually sleeping) make the limiter's timing fully testable with
+ * no wall-clock waits.
+ */
+public class NcbiRateLimiterTest {
+
+    /** Fake monotonic clock, in nanoseconds. */
+    private final long[] nowNanos = {0L};
+    /** Records every requested sleep (ns); a sleep advances the fake clock by that amount. */
+    private final List<Long> sleeps = new ArrayList<>();
+
+    // TestNG reuses one instance across @Test methods and does not reset fields between them, so
+    // reset the fake clock and recorded sleeps before each test to keep them independent.
+    @BeforeMethod
+    public void resetClock() {
+        nowNanos[0] = 0L;
+        sleeps.clear();
+    }
+
+    private NcbiRateLimiter limiter(double permitsPerSecond, boolean enabled) {
+        return new NcbiRateLimiter(permitsPerSecond, enabled,
+                () -> nowNanos[0],
+                nanos -> { sleeps.add(nanos); nowNanos[0] += nanos; });
+    }
+
+    private static long millisToNanos(long millis) {
+        return TimeUnit.MILLISECONDS.toNanos(millis);
+    }
+
+    @Test
+    public void firstPermitIsImmediateThenSpacedAtTheConfiguredRate() {
+        NcbiRateLimiter limiter = limiter(2.0, true); // 2/s => 500ms spacing
+
+        limiter.acquire(); // #1 immediate
+        limiter.acquire(); // #2 waits one interval
+        limiter.acquire(); // #3 waits another interval
+
+        assertEquals(sleeps.size(), 2, "Only the 2nd and 3rd acquires should wait; the first is immediate");
+        assertEquals((long) sleeps.get(0), millisToNanos(500), "2nd permit must wait one 500ms interval");
+        assertEquals((long) sleeps.get(1), millisToNanos(500), "3rd permit must wait one more 500ms interval");
+    }
+
+    @Test
+    public void pauseForMakesTheNextAcquireWaitOutTheRetryAfter() {
+        NcbiRateLimiter limiter = limiter(2.0, true);
+
+        limiter.acquire();      // #1 immediate, advances next permit by 500ms
+        limiter.pauseFor(3);    // Retry-After: 3s — must dominate the 500ms spacing
+        limiter.acquire();      // #2 must wait ~3s
+
+        assertEquals(sleeps.size(), 1, "Only the post-pause acquire should sleep");
+        assertEquals((long) sleeps.get(0), TimeUnit.SECONDS.toNanos(3),
+                "After pauseFor(3) the next permit must wait the full 3s Retry-After");
+    }
+
+    @Test
+    public void longestPauseWins() {
+        NcbiRateLimiter limiter = limiter(100.0, true); // tiny spacing so pauses dominate
+
+        limiter.pauseFor(2);
+        limiter.pauseFor(5);
+        limiter.pauseFor(1); // shorter than the already-set 5s pause; must not shorten it
+        limiter.acquire();
+
+        assertEquals((long) sleeps.get(0), TimeUnit.SECONDS.toNanos(5),
+                "The longest outstanding pause must win");
+    }
+
+    @Test
+    public void disabledLimiterNeverWaits() {
+        NcbiRateLimiter limiter = limiter(2.0, false);
+
+        for (int i = 0; i < 5; i++) {
+            limiter.acquire();
+        }
+        limiter.pauseFor(10);
+        limiter.acquire();
+
+        assertTrue(sleeps.isEmpty(), "A disabled limiter must never sleep or pause");
+    }
+
+    @Test
+    public void nonPositiveRateIsRejected() {
+        try {
+            limiter(0.0, true);
+            fail("Expected IllegalArgumentException for a non-positive rate");
+        } catch (IllegalArgumentException expected) {
+            assertTrue(expected.getMessage().contains("permits-per-second"),
+                    "Message should name the offending property");
+        }
+    }
+}

--- a/src/test/java/reciter/pubmed/xmlparser/PubmedEFetchHandlerTest.java
+++ b/src/test/java/reciter/pubmed/xmlparser/PubmedEFetchHandlerTest.java
@@ -18,14 +18,18 @@ import org.xml.sax.InputSource;
 import lombok.extern.slf4j.Slf4j;
 import reciter.model.pubmed.PubMedArticle;
 import reciter.pubmed.callable.PubMedUriParserCallable;
+import reciter.pubmed.ratelimit.NcbiRateLimiter;
 
 @Slf4j
 public class PubmedEFetchHandlerTest {
-	
+
 	private PubmedEFetchHandler xmlHandler;
     private SAXParser saxParser;
     private InputSource inputSource;
     private PubMedUriParserCallable pubMedUriParserCallable;
+    // These fixtures parse local files/resources (systemId is null), so the rate limiter is never
+    // exercised; a disabled instance just satisfies the constructor.
+    private final NcbiRateLimiter rateLimiter = new NcbiRateLimiter(2.0, false);
 
     @BeforeClass
     public void setup() throws Exception {
@@ -41,7 +45,7 @@ public class PubmedEFetchHandlerTest {
     public void testJournalTitleParse() throws Exception {
         File initialFile = new File("src/test/resources/reciter/pubmed/callable/31967741.xml");
         inputSource = new InputSource(new FileInputStream(initialFile));
-        pubMedUriParserCallable = new PubMedUriParserCallable(xmlHandler, saxParser, inputSource);
+        pubMedUriParserCallable = new PubMedUriParserCallable(xmlHandler, saxParser, inputSource, rateLimiter);
         List<PubMedArticle> pubMedArticles = pubMedUriParserCallable.call();
         PubMedArticle pubMedArticle = pubMedArticles.get(0);
         String journalTitle = pubMedArticle.getMedlinecitation().getArticle().getJournal().getTitle();
@@ -49,7 +53,7 @@ public class PubmedEFetchHandlerTest {
 
         initialFile = new File("src/test/resources/reciter/pubmed/callable/31746150.xml");
         inputSource = new InputSource(new FileInputStream(initialFile));
-        pubMedUriParserCallable = new PubMedUriParserCallable(xmlHandler, saxParser, inputSource);
+        pubMedUriParserCallable = new PubMedUriParserCallable(xmlHandler, saxParser, inputSource, rateLimiter);
         pubMedArticles = pubMedUriParserCallable.call();
         pubMedArticle = pubMedArticles.get(0);
         journalTitle = pubMedArticle.getMedlinecitation().getArticle().getJournal().getTitle();
@@ -59,7 +63,7 @@ public class PubmedEFetchHandlerTest {
     @Test
     public void testAuthorOrcid() throws Exception {
         inputSource = new InputSource(this.getClass().getResourceAsStream("31482638.xml"));
-        pubMedUriParserCallable = new PubMedUriParserCallable(xmlHandler, saxParser, inputSource);
+        pubMedUriParserCallable = new PubMedUriParserCallable(xmlHandler, saxParser, inputSource, rateLimiter);
         List<PubMedArticle> pubMedArticles = pubMedUriParserCallable.call();
         PubMedArticle pubMedArticle = pubMedArticles.get(0);
         log.debug(pubMedArticle.getMedlinecitation().getArticle().getAuthorlist().get(0).getOrcid());
@@ -78,7 +82,7 @@ public class PubmedEFetchHandlerTest {
     @Test
     public void testEqualContribDeduplication() throws Exception {
         inputSource = new InputSource(this.getClass().getResourceAsStream("equalcontrib.xml"));
-        pubMedUriParserCallable = new PubMedUriParserCallable(xmlHandler, saxParser, inputSource);
+        pubMedUriParserCallable = new PubMedUriParserCallable(xmlHandler, saxParser, inputSource, rateLimiter);
         List<PubMedArticle> pubMedArticles = pubMedUriParserCallable.call();
         PubMedArticle pubMedArticle = pubMedArticles.get(0);
 
@@ -102,7 +106,7 @@ public class PubmedEFetchHandlerTest {
     @Test
     public void testReferenceList() throws Exception {
         inputSource = new InputSource(this.getClass().getResourceAsStream("32025781.xml"));
-        pubMedUriParserCallable = new PubMedUriParserCallable(xmlHandler, saxParser, inputSource);
+        pubMedUriParserCallable = new PubMedUriParserCallable(xmlHandler, saxParser, inputSource, rateLimiter);
         List<PubMedArticle> pubMedArticles = pubMedUriParserCallable.call();
         PubMedArticle pubMedArticle = pubMedArticles.get(0);
         assertEquals(38, pubMedArticle.getMedlinecitation().getCommentscorrectionslist().size(), "The referenceList matches");
@@ -111,7 +115,7 @@ public class PubmedEFetchHandlerTest {
     @Test
     public void testArticleTitleLineBreakRemoval() throws Exception {
         inputSource = new InputSource(this.getClass().getResourceAsStream("32025781.xml"));
-        pubMedUriParserCallable = new PubMedUriParserCallable(xmlHandler, saxParser, inputSource);
+        pubMedUriParserCallable = new PubMedUriParserCallable(xmlHandler, saxParser, inputSource, rateLimiter);
         List<PubMedArticle> pubMedArticles = pubMedUriParserCallable.call();
         PubMedArticle pubMedArticle = pubMedArticles.get(0);
         assertEquals("<b> <i>Propionibacterium acnes</i> </b> Host Inflammatory Response During Periprosthetic Infection Is Joint Specific.", pubMedArticle.getMedlinecitation().getArticle().getArticletitle(), "The ArticleTitle matches");
@@ -120,7 +124,7 @@ public class PubmedEFetchHandlerTest {
     @Test
     public void testHexadecimalLiteralRemoval() throws Exception {
         inputSource = new InputSource(this.getClass().getResourceAsStream("32025781.xml"));
-        pubMedUriParserCallable = new PubMedUriParserCallable(xmlHandler, saxParser, inputSource);
+        pubMedUriParserCallable = new PubMedUriParserCallable(xmlHandler, saxParser, inputSource, rateLimiter);
         List<PubMedArticle> pubMedArticles = pubMedUriParserCallable.call();
         String articleTitle = pubMedArticles.get(0).getMedlinecitation().getArticle().getArticletitle();
         assertEquals("<b> <i>Propionibacterium acnes</i> </b> Host Inflammatory Response During Periprosthetic Infection Is Joint Specific.", articleTitle);


### PR DESCRIPTION
Closes #117. Implements **Phase 0 + Phase 1** of `docs/rate-limiter-design-117.md` (merged in #151).

### Problem
NCBI enforces its quota **per API key** (~10 req/s with a key, 3 req/s without), shared across every process using that key. With the HPA allowing up to 4 pods and a 50-connection HTTP pool per pod, nothing capped the service's outbound NCBI rate. EFetch ignored rate-limit headers entirely (raw `URLConnection`), and `Retry-After` was honored only on ESearch, only once, by sleeping the calling servlet thread.

### Change
- **`NcbiRateLimiter`** — a single shared bean: a per-pod token bucket (configurable permits/sec) **plus a shared `Retry-After` pause deadline**. Small, deterministic, clock-injectable; **no new dependency** (avoids Guava's `@Beta` `RateLimiter`).
- `acquire()` is called before **both** the ESearch POST and the EFetch GET → all in-pod NCBI traffic draws from **one** budget (the "shared cross-thread limiter" #117 asks for).
- **EFetch now reads the response code**; on HTTP 429/503 it pauses the shared limiter for the server's `Retry-After` and throws `IOException` so the outer `@Retryable` re-enters (the next `acquire()` waits the pause out). Closes the "honor Retry-After on EFetch" gap.
- ESearch's existing `Retry-After` handling now **pauses the shared limiter** instead of sleeping one thread, so a throttle seen by one request backs off every request in the pod.
- Config: `pubmed.ratelimit.permits-per-second` (default `2.0` ≈ 10/s ÷ 4 pods ÷ headroom), `pubmed.ratelimit.enabled` (default `true`).

Cross-**pod** coordination (design Options 2/3) is deliberately out of scope, deferred behind measurement.

### Verification (JDK 11)
- `mvn clean test` curated suite + new `NcbiRateLimiterTest` — **20/20 pass** (spacing, Retry-After pause, longest-pause-wins, disabled no-op, rate validation; deterministic via injected clock/sleeper).
- Runtime on :8083 — startup logs `NCBI rate limiter enabled: 2.0 permit(s)/sec (500 ms spacing)`; a live query returns 120 articles as valid JSON; the `?fields=` filter still works.
- **Concurrency**: 4 parallel queries (8 permits @2/s) all returned HTTP 200, staggered 2.9s→4.4s (wall-clock 4.5s ≈ the expected throttling), no deadlock, no errors.