### PR TITLE
#120: replace abandoned Springfox 3.0.0 with springdoc-openapi

### DIFF
--- a/kubernetes/k8-configmap.yaml
+++ b/kubernetes/k8-configmap.yaml
@@ -64,7 +64,7 @@ data:
             proxy_connect_timeout 300s;
         }
 
-        location /pubmed/v2 {
+        location /pubmed/v3 {
             rewrite ^/pubmed/(.*)$ /$1 break;
             proxy_pass http://localhost:5000;
             proxy_redirect off;

--- a/nginx/conf.d/reciter-pubmed.conf
+++ b/nginx/conf.d/reciter-pubmed.conf
@@ -56,7 +56,7 @@ server {
             proxy_connect_timeout 300s;
         }
 
-        location /pubmed/v2 {
+        location /pubmed/v3 {
             rewrite ^/pubmed/(.*)$ /$1 break;
             proxy_pass http://app:5000;
             proxy_redirect off;

--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,22 @@
         <java.version>11</java.version>
     </properties>
 
+    <dependencyManagement>
+        <dependencies>
+            <!-- Pin swagger-models to the version springdoc-openapi 1.8.0's swagger-core (2.2.20)
+                 expects. The reciter-pubmed-model dependency transitively drags in the unused
+                 swagger-codegen maven plugin, which forces the ancient swagger-models 2.0.0; that
+                 old version is missing classes springdoc references and breaks startup (#120).
+                 Pinning here (rather than excluding swagger-codegen) avoids disturbing other
+                 libraries the build picks up transitively through that same chain. -->
+            <dependency>
+                <groupId>io.swagger.core.v3</groupId>
+                <artifactId>swagger-models</artifactId>
+                <version>2.2.20</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -37,11 +53,15 @@
         <!-- Jackson is managed by the Spring Boot 2.7 BOM (currently 2.13.x), which supersedes the
              explicit 2.12.x CVE pins that were required under Boot 2.5. Do not re-pin Jackson here:
              bump Spring Boot to move Jackson, so the whole stack stays version-aligned. -->
+        <!-- OpenAPI/Swagger UI via springdoc-openapi (replaces the abandoned Springfox 3.0.0, #120).
+             1.8.0 is the last 1.x release and the one compatible with Spring Boot 2.7 / javax;
+             springdoc 2.x requires Spring Boot 3 / jakarta and is the upgrade target for epic #136.
+             Serves Swagger UI at /swagger-ui/index.html and the OpenAPI JSON at /v3/api-docs. -->
         <dependency>
-			<groupId>io.springfox</groupId>
-			<artifactId>springfox-boot-starter</artifactId>
-			<version>3.0.0</version>
-		</dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-ui</artifactId>
+            <version>1.8.0</version>
+        </dependency>
         <!-- https://mvnrepository.com/artifact/org.projectlombok/lombok -->
         <dependency>
             <groupId>org.projectlombok</groupId>

--- a/src/main/java/reciter/controller/PingController.java
+++ b/src/main/java/reciter/controller/PingController.java
@@ -1,8 +1,8 @@
 package reciter.controller;
 
 
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiOperation;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -11,10 +11,10 @@ import org.springframework.web.bind.annotation.ResponseBody;
 
 @Controller
 @RequestMapping("/pubmed")
-@Api(value = "PingController", description = "Health Check.")
+@Tag(name = "Ping Controller", description = "Health Check.")
 public class PingController {
 
-    @ApiOperation(value = "Health check", response = ResponseEntity.class)
+    @Operation(summary = "Health check")
     @RequestMapping(value = "/ping", method = RequestMethod.GET, produces = "text/plain")
     @ResponseBody
     public ResponseEntity<String> ping() {

--- a/src/main/java/reciter/controller/PubMedRetrievalToolController.java
+++ b/src/main/java/reciter/controller/PubMedRetrievalToolController.java
@@ -22,10 +22,10 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiResponse;
-import io.swagger.annotations.ApiResponses;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.extern.slf4j.Slf4j;
 import reciter.model.pubmed.PubMedArticle;
 import reciter.pubmed.model.PubMedQuery;
@@ -34,18 +34,18 @@ import reciter.pubmed.retriever.PubMedArticleRetrievalService;
 @Slf4j
 @Controller
 @RequestMapping("/pubmed")
-@Api(value = "PubMedController", description = "Operations on querying the PubMed API.")
+@Tag(name = "PubMed Controller", description = "Operations on querying the PubMed API.")
 public class PubMedRetrievalToolController {
 
     @Autowired
     private PubMedArticleRetrievalService pubMedArticleRetrievalService;
 
-    @ApiOperation(value = "Query with field selection.", response = List.class)
+    @Operation(summary = "Query with field selection.")
     @ApiResponses(value = {
-            @ApiResponse(code = 200, message = "Successfully retrieved list"),
-            @ApiResponse(code = 401, message = "You are not authorized to view the resource"),
-            @ApiResponse(code = 403, message = "Accessing the resource you were trying to reach is forbidden"),
-            @ApiResponse(code = 404, message = "The resource you were trying to reach is not found")
+            @ApiResponse(responseCode = "200", description = "Successfully retrieved list"),
+            @ApiResponse(responseCode = "401", description = "You are not authorized to view the resource"),
+            @ApiResponse(responseCode = "403", description = "Accessing the resource you were trying to reach is forbidden"),
+            @ApiResponse(responseCode = "404", description = "The resource you were trying to reach is not found")
     })
     @RequestMapping(value = "/query/{query}", method = RequestMethod.GET, produces = "application/json")
     @ResponseBody

--- a/src/main/java/reciter/swagger/SwaggerConfig.java
+++ b/src/main/java/reciter/swagger/SwaggerConfig.java
@@ -3,36 +3,34 @@ package reciter.swagger;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-import springfox.documentation.builders.ApiInfoBuilder;
-import springfox.documentation.builders.RequestHandlerSelectors;
-import springfox.documentation.service.ApiInfo;
-import springfox.documentation.service.Contact;
-import springfox.documentation.spi.DocumentationType;
-import springfox.documentation.spring.web.plugins.Docket;
-import springfox.documentation.swagger2.annotations.EnableSwagger2;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Contact;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.info.License;
 
-import static springfox.documentation.builders.PathSelectors.regex;
-
+/**
+ * OpenAPI/Swagger configuration via springdoc-openapi (#120, replacing the abandoned Springfox).
+ *
+ * <p>springdoc auto-detects the controller request mappings, so no Docket/path selection is needed:
+ * every endpoint in this service is under {@code /pubmed}. This bean only supplies the API metadata.
+ * Swagger UI is served at {@code /swagger-ui/index.html} and the OpenAPI JSON at {@code /v3/api-docs}.
+ */
 @Configuration
-@EnableSwagger2
 public class SwaggerConfig {
-    @Bean
-    public Docket productApi() {
-        return new Docket(DocumentationType.SWAGGER_2)
-                .select()
-                .apis(RequestHandlerSelectors.basePackage("reciter.controller"))
-                .paths(regex("/pubmed.*"))
-                .build()
-                .apiInfo(apiInfo());
-    }
 
-    private ApiInfo apiInfo() {
-        return new ApiInfoBuilder().title("ReCiter publication management system - PubMed Retrieval Tool")
-                .description("Retrieve publications and publication counts from PubMed. More info here: https://github.com/wcmc-its/ReCiter-PubMed-Retrieval-Tool/").termsOfServiceUrl("")
-                .contact(new Contact("Paul J. Albert", "https://github.com/wcmc-its/ReCiter", "paa2013@med.cornell.edu"))
-                .license("Apache License Version 2.0")
-                .licenseUrl("https://www.apache.org/licenses/LICENSE-2.0")
+    @Bean
+    public OpenAPI pubMedRetrievalToolOpenAPI() {
+        return new OpenAPI().info(new Info()
+                .title("ReCiter publication management system - PubMed Retrieval Tool")
+                .description("Retrieve publications and publication counts from PubMed. More info here: "
+                        + "https://github.com/wcmc-its/ReCiter-PubMed-Retrieval-Tool/")
                 .version("1.1.0")
-                .build();
+                .contact(new Contact()
+                        .name("Paul J. Albert")
+                        .url("https://github.com/wcmc-its/ReCiter")
+                        .email("paa2013@med.cornell.edu"))
+                .license(new License()
+                        .name("Apache License Version 2.0")
+                        .url("https://www.apache.org/licenses/LICENSE-2.0")));
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,9 +1,5 @@
 server.port=5000
 
-# Spring Boot 2.6+ defaults to PATH_PATTERN_PARSER, which fails at startup with
-# Springfox 3.0.0. Keep the legacy AntPathMatcher so Swagger/Springfox loads.
-spring.mvc.pathmatch.matching-strategy=ANT_PATH_MATCHER
-
 # NCBI E-utilities per-pod rate limiter (issue #117). NCBI enforces its quota per API key
 # (~10 req/s with a key, 3 req/s without), shared across every process using that key. Each pod
 # is smoothed to a fraction of that budget so pods x rate stays under quota (the HPA allows up to


### PR DESCRIPTION
Closes #120 (on dev; promotes to master/prod separately).

Springfox 3.0.0 has been unmaintained since 2020, is incompatible with Spring Boot 3, and drags in old guava/swagger transitives — it's a blocker for the Boot 3 / Java 17 epic (#136).

### Change
- **pom**: `io.springfox:springfox-boot-starter:3.0.0` → `org.springdoc:springdoc-openapi-ui:1.8.0` (last 1.x; Boot 2.7 / javax — springdoc 2.x targets Boot 3 / jakarta, for #136).
- **SwaggerConfig**: Springfox `Docket` → springdoc `OpenAPI` bean (same title/description/version/contact/license).
- **Controllers**: migrate Swagger-1.x annotations (`io.swagger.annotations.*`: `@Api`/`@ApiOperation`/`@ApiResponse(s)`) → OpenAPI-3 (`io.swagger.v3.oas.annotations.*`: `@Tag`/`@Operation`/`@ApiResponse(s)`).
- **application.properties**: **removed** the `spring.mvc.pathmatch.matching-strategy=ANT_PATH_MATCHER` workaround — it existed only for Springfox; springdoc starts fine on Boot 2.7's default `PathPatternParser` (verified at runtime).
- **pom `dependencyManagement`**: pin `io.swagger.core.v3:swagger-models` to `2.2.20`. `reciter-pubmed-model` transitively pulls the unused `swagger-codegen` maven plugin, which forces the ancient `swagger-models:2.0.0`; that version is missing classes springdoc references and **fails startup**. Pinning (rather than excluding swagger-codegen) avoids disturbing other libraries the build picks up through that same chain. *(That pre-existing `reciter-pubmed-model` bloat is worth a separate hygiene pass, à la #119/#144.)*
- **nginx** (`conf.d` + k8 configmap): api-docs proxy route `/pubmed/v2` → `/pubmed/v3`.

### Verification (JDK 11)
- `mvn clean test` curated suite + limiter test — **20/20 pass**; full annotation migration compiles.
- Runtime on :8083: app **starts cleanly** with the ANT_PATH_MATCHER workaround removed; `/v3/api-docs` → 200 OpenAPI 3.0.1 with the correct info + all 4 endpoints + both `@Tag`s; `/swagger-ui/index.html` → 200, `/swagger-ui.html` → 302; `/pubmed/ping` → Healthy; a live `/pubmed/query/...` returns 120 articles.

### Note for reviewers (reverse proxy)
Behind nginx/ALB the service is under the `/pubmed` prefix. Swagger UI assets and `/pubmed/v3/api-docs` are proxied; if the hosted UI's "Try it out" needs the prefixed docs URL, set `springdoc.swagger-ui.config-url`/`springdoc.api-docs.path` at deploy time. Local (direct) access is fully working.