### PR TITLE
Promote dev → master: Jackson cleanup, deploy/rate-limiter docs, #117 rate limiter, #120 springdoc

### DIFF
--- a/docs/deploy-and-approval-runbook.md
+++ b/docs/deploy-and-approval-runbook.md
@@ -1,0 +1,428 @@
+# Deploy & Approval Runbook — ReCiter-PubMed-Retrieval-Tool
+
+A durable how-to for building, deploying, and approving releases of the
+ReCiter-PubMed-Retrieval-Tool Spring Boot microservice to EKS via AWS CodeBuild /
+CodePipeline. This is an operational runbook, not an incident report. Read it before
+touching the pipeline, the `PubMedService` CodeBuild project, or either buildspec.
+
+> Conventions in this doc:
+> - "confirmed" = verified against a repo file or a live `aws` CLI call on 2026-06-13.
+> - "as configured" = asserted from project memory / prior sessions but not re-verified
+>   from a file or the API in this writing; treat these as facts to re-check (they are
+>   listed in the handoff `keyClaims`).
+> - Region is `us-east-1` throughout. Account `665083158573` (IAM user `reciter`).
+
+---
+
+## 1. Architecture
+
+### Build & deploy system
+
+A single AWS **CodeBuild project named `PubMedService`** builds the service and
+deploys it to the EKS cluster. Confirmed live configuration:
+
+| Property | Value | Source |
+|----------|-------|--------|
+| CodeBuild project name | `PubMedService` | `aws codebuild batch-get-projects` |
+| Image | `aws/codebuild/amazonlinux2-x86_64-standard:5.0` | confirmed live |
+| Compute type | `BUILD_GENERAL1_SMALL` | confirmed live |
+| Environment type | `LINUX_CONTAINER` | confirmed live |
+| Source type | `GITHUB` (`wcmc-its/ReCiter-PubMed-Retrieval-Tool`) | confirmed live |
+| Buildspec | `k8-buildspec.yml` | confirmed live |
+| Buildspec runtime | `java: corretto11` | `k8-buildspec.yml` line 6 |
+
+The same `PubMedService` project is driven by **both** the Dev and prod pipelines.
+The pipeline injects a `BRANCH` environment variable (`#{SourceVariables.BranchName}`)
+that the buildspec uses to decide which environment to target (`dev` vs `master`).
+
+### Two buildspecs
+
+| File | Purpose | Status |
+|------|---------|--------|
+| `buildspec.yml` | Legacy Elastic Beanstalk packaging (artifacts: jar + `.ebextensions` + `Procfile`) | retained, **not** the EKS path |
+| `k8-buildspec.yml` | Kubernetes / EKS build + image push + `kubectl set image` deploy | **active** path used by `PubMedService` |
+
+The EKS deploy uses `k8-buildspec.yml`. `buildspec.yml` is kept for the legacy
+Beanstalk flow and as a minimal compile/test definition; do not delete it without
+confirming nothing references it.
+
+### Curated tests — load test is NEVER run
+
+Both buildspecs run a curated subset of unit tests and deliberately exclude the live
+load tests:
+
+```bash
+mvn clean install \
+  -Dtest=PubmedEFetchHandlerTest,PubMedUriParserCallableTest,PubMedArticleRetrievalServiceTest \
+  -DfailIfNoTests=false
+```
+
+(`buildspec.yml` line 17; `k8-buildspec.yml` line 50.)
+
+The load tests `ReCiterPubmedApiLoadTest` / `LoadTest` are **never** executed in CI:
+they make live HTTP calls to a running service and return **403 Forbidden** when no
+service is up. Do not add them to the `-Dtest` list and do not remove the
+`-Dtest=` filter (which would run the whole suite, including the load tests).
+
+> Runtime-verification gap: the curated unit tests parse local fixtures with no
+> DOCTYPE, and the load test is skipped, so neither catches live-path regressions in
+> the SAX parser / HTTP client. For changes touching the parser, HTTP client, deps,
+> or the Boot version, **boot the jar and run a real query** (see Section 7).
+
+### CodeBuild environment variables — MUST be preserved
+
+The `PubMedService` project relies on exactly four environment variables. Confirmed
+present live:
+
+- `REPOSITORY_URI` — ECR repo URI for the image (`<acct>.dkr.ecr.us-east-1.amazonaws.com/<repo>`)
+- `EKS_KUBECTL_ROLE_ARN` — IAM role assumed to run `kubectl` against the cluster
+- `EKS_CLUSTER_NAME` — EKS cluster name (also used as the kubectl `-n` namespace in the buildspec)
+- `DOCKER_HUB_CREDENTIALS_ARN` — Secrets Manager ARN for Docker Hub login (avoids anonymous pull rate limits)
+
+**Critical:** `aws codebuild update-project --environment` **REPLACES the entire
+environment block**. Any update that passes `--environment` must re-list all four
+variables or they will be silently dropped, breaking the deploy. See Section 4(c).
+
+### Runtime topology (what gets deployed)
+
+- EKS cluster `reciter`, namespace `reciter` *(as configured)*.
+- Deployments: **`reciter-pubmed-dev`** and **`reciter-pubmed-prod`** (rendered from
+  `kubernetes/k8-deployment.yaml` via `sed` token substitution in the buildspec).
+- Each pod is **2 containers**: the app (`reciter-pubmed`, port 5000) and an `nginx`
+  sidecar (port 80) that reverse-proxies `/pubmed/*` to `localhost:5000`. A healthy
+  rolled pod therefore shows **`2/2` Ready**.
+- App container runs as non-root UID/GID `10001`, `JAVA_OPTIONS=-Xmx2000m`,
+  `PUBMED_API_KEY` from secret `pubmed-secret`, `SERVER_PORT` from configmap
+  `env-config-dev` / `env-config-prod`.
+- Health endpoint: `GET /pubmed/ping` → `Healthy` (used by liveness/readiness probes
+  on port 5000; nginx liveness/readiness use `/nginx-health` on port 80).
+- HPA: `hpa-reciter-pubmed-dev` / `hpa-reciter-pubmed-prod`, min 1 / max 4 replicas,
+  CPU 80% / memory 85% targets.
+- Nodes: `nodeSelector: lifecycle: Ec2Spot`.
+
+---
+
+## 2. Pipeline flow
+
+Both pipelines have the **same three-stage shape** (confirmed live):
+`Source → ManualApproval → Build`. There is **no separate CodePipeline Deploy
+stage** — the deploy is performed inside the CodeBuild `Build` stage by the buildspec
+(`docker push` + `aws eks update-kubeconfig` + `kubectl set image`). Approval gates
+the **build+deploy**, not a downstream deploy action.
+
+### Dev flow
+
+Pipeline: **`ReCiter-Pubmed-Retrieval-Tool-Dev`** (Source branch `dev`, confirmed).
+
+```
+push / merge to `dev`
+  → CodePipeline Source (GitHub, branch dev)
+  → ManualApproval gate            (agent/user may approve dev)
+  → Build (CodeBuild PubMedService, BRANCH=dev)
+        mvn curated tests → docker build/push $REPOSITORY_URI:dev-<n>...
+        aws eks update-kubeconfig --role-arn $EKS_KUBECTL_ROLE_ARN
+        kubectl set image deployment/reciter-pubmed-dev reciter-pubmed=$REPOSITORY_URI:<tag> -n $EKS_CLUSTER_NAME
+  → verify: pod reciter-pubmed-dev rolled, 2/2 Ready, /pubmed/ping = Healthy
+```
+
+Dev approvals are routine and may be approved by the agent or user.
+
+Verify a dev rollout:
+
+```bash
+aws eks update-kubeconfig --name reciter --region us-east-1   # or assume EKS_KUBECTL_ROLE_ARN
+kubectl -n reciter rollout status deployment/reciter-pubmed-dev
+kubectl -n reciter get pods -l app=reciter-pubmed-dev          # expect 2/2 Ready
+kubectl -n reciter get deployment reciter-pubmed-dev \
+  -o jsonpath='{.spec.template.spec.containers[0].image}{"\n"}'   # confirm new tag
+```
+
+> A second, parallel dev pipeline `ReCiter-Pubmed-Retrieval-Tool-Dev_V2` also exists
+> (confirmed in `list-pipelines`). Confirm which dev pipeline is the live one before
+> approving — do not approve both for the same change.
+
+### Prod flow
+
+Pipeline: **`ReCiter-Pubmed-Retrieval-Tool-prod`** (Source branch `master`, confirmed).
+
+```
+merge to `master`
+  → CodePipeline Source (GitHub, branch master)
+  → ManualApproval gate            (NON-hotfix: mrj4001 only — see Section 3)
+  → Build (CodeBuild PubMedService, BRANCH=master)
+        mvn curated tests → docker build/push $REPOSITORY_URI:master-<n>...
+        kubectl set image deployment/reciter-pubmed-prod reciter-pubmed=$REPOSITORY_URI:<tag> -n $EKS_CLUSTER_NAME
+  → verify: pod reciter-pubmed-prod rolled, 2/2 Ready
+```
+
+Verify a prod rollout (swap `dev`→`prod` in the dev commands above):
+
+```bash
+kubectl -n reciter rollout status deployment/reciter-pubmed-prod
+kubectl -n reciter get pods -l app=reciter-pubmed-prod          # expect 2/2 Ready
+kubectl -n reciter get deployment reciter-pubmed-prod \
+  -o jsonpath='{.spec.template.spec.containers[0].image}{"\n"}'
+```
+
+---
+
+## 3. Approval policy
+
+**Non-hotfix production deploys MUST be approved by `mrj4001`** at the
+`ReCiter-Pubmed-Retrieval-Tool-prod` ManualApproval gate. The agent and the requesting
+user (`paa2013`) must **not** rubber-stamp routine or catch-up prod releases — leave
+the gate pending and hand off / notify `mrj4001`.
+
+**Hotfixes are the carve-out** and may be fast-tracked (approved promptly by
+agent/user) — e.g. a live-outage fix such as the EFetch DOCTYPE-parsing hotfix. Use
+judgment: a "hotfix" is a narrowly-scoped fix for an active production defect, not a
+bundle of accumulated changes.
+
+**Dev approvals** are routine and may be approved by the agent/user.
+
+### Notification channel
+
+The approval gate notifies the SNS topic **`reciter-pipeline-validation`**
+(`arn:aws:sns:us-east-1:665083158573:reciter-pipeline-validation`, confirmed).
+
+Current email subscribers (confirmed live, 2026-06-13):
+
+| Endpoint | Protocol |
+|----------|----------|
+| `paa2013@med.cornell.edu` | email |
+| `szd2013@med.cornell.edu` | email |
+
+> **ENABLEMENT GAP (action item, not a permanent fact):** `mrj4001` is **not** yet a
+> subscriber of `reciter-pipeline-validation`, yet policy requires them to approve
+> non-hotfix prod deploys. To close the gap, `mrj4001` needs:
+> 1. an **email subscription** to the topic, and
+> 2. console **`codepipeline:PutApprovalResult`** access (federated/SSO — `mrj4001`
+>    is a CWID, not an IAM user) *(as configured)*.
+>
+> Subscribe (then `mrj4001` must click the confirmation email):
+> ```bash
+> aws sns subscribe \
+>   --topic-arn arn:aws:sns:us-east-1:665083158573:reciter-pipeline-validation \
+>   --protocol email \
+>   --notification-endpoint mrj4001@med.cornell.edu
+> ```
+> Until this is done, `mrj4001` will not receive gate notifications; coordinate the
+> hand-off out of band.
+
+---
+
+## 4. Gotchas (read before approving or editing the project)
+
+### (a) Stale executions pile up at the ManualApproval gate
+
+Because approvals are manual and several executions can queue (e.g. a superseded
+older build still holding a token), **the token surfaced at the gate may not belong
+to the execution you want to deploy.** Approving a stale token returns an `approvedAt`
+timestamp but does **not** advance the latest revision.
+
+Always map **approval token → execution → revision** before acting, and **reject**
+stale gate-holders so the latest can advance.
+
+```bash
+PIPE=ReCiter-Pubmed-Retrieval-Tool-prod
+
+# What is sitting at the gate right now (token + which execution holds it)?
+aws codepipeline get-pipeline-state --name "$PIPE" \
+  --query 'stageStates[?stageName==`ManualApproval`].actionStates[0].latestExecution' \
+  --output json
+
+# Map that execution to its source revision (commit) so you know what you'd ship.
+aws codepipeline list-pipeline-executions --pipeline-name "$PIPE" \
+  --max-items 10 \
+  --query 'pipelineExecutionSummaries[*].{id:pipelineExecutionId,status:status,rev:sourceRevisions[0].revisionId,summary:sourceRevisions[0].revisionSummary}' \
+  --output table
+```
+
+Reject a stale holder so a newer execution can take the gate:
+
+```bash
+aws codepipeline put-approval-result \
+  --pipeline-name "$PIPE" \
+  --stage-name ManualApproval \
+  --action-name ManualApproval \
+  --token <STALE_TOKEN> \
+  --result status=Rejected,summary='superseded by newer execution'
+```
+
+### (b) `put-approval-result --result` shorthand breaks on a comma in `summary=`
+
+The CLI shorthand parses `key=value,key=value`, so a **comma inside the `summary`
+text** is read as a new key and the call fails. Either omit commas, or pass the
+result as JSON.
+
+Broken (comma inside summary):
+```bash
+# FAILS — the comma after "approved" is parsed as a field separator
+--result status=Approved,summary='approved, deploying master'
+```
+
+Works (no comma):
+```bash
+--result status=Approved,summary='approved deploying master'
+```
+
+Works (JSON form — safe with commas/quotes):
+```bash
+aws codepipeline put-approval-result \
+  --pipeline-name ReCiter-Pubmed-Retrieval-Tool-prod \
+  --stage-name ManualApproval \
+  --action-name ManualApproval \
+  --token <LIVE_TOKEN> \
+  --result '{"status":"Approved","summary":"approved by mrj4001, master catch-up"}'
+```
+
+### (c) `update-project --environment` REPLACES the whole environment block
+
+Any `aws codebuild update-project` that touches `--environment` must re-list **all
+four** env vars (`REPOSITORY_URI`, `EKS_KUBECTL_ROLE_ARN`, `EKS_CLUSTER_NAME`,
+`DOCKER_HUB_CREDENTIALS_ARN`) or they are dropped and the deploy breaks. Read the
+current values first, change only what you intend, and write them all back.
+
+```bash
+# 1. Dump the current environment so you don't lose anything.
+aws codebuild batch-get-projects --names PubMedService \
+  --query 'projects[0].environment' --output json
+
+# 2. Re-apply ALL four env vars even when you are only changing the image.
+aws codebuild update-project --name PubMedService --environment '{
+  "type": "LINUX_CONTAINER",
+  "image": "aws/codebuild/amazonlinux2-x86_64-standard:5.0",
+  "computeType": "BUILD_GENERAL1_SMALL",
+  "privilegedMode": true,
+  "environmentVariables": [
+    {"name":"REPOSITORY_URI",            "value":"<value>", "type":"PLAINTEXT"},
+    {"name":"EKS_KUBECTL_ROLE_ARN",      "value":"<value>", "type":"PLAINTEXT"},
+    {"name":"EKS_CLUSTER_NAME",          "value":"<value>", "type":"PLAINTEXT"},
+    {"name":"DOCKER_HUB_CREDENTIALS_ARN","value":"<value>", "type":"PLAINTEXT"}
+  ]
+}'
+
+# 3. Verify all four survived.
+aws codebuild batch-get-projects --names PubMedService \
+  --query 'projects[0].environment.environmentVariables[*].name' --output json
+```
+
+> `privilegedMode: true` is required because the buildspec runs `docker build`/`docker
+> push` (confirmed live via `aws codebuild batch-get-projects --names PubMedService` on
+> 2026-06-13).
+
+### (d) Any buildspec edit must keep three things
+
+When editing `buildspec.yml` or `k8-buildspec.yml`, preserve all of:
+
+1. **`runtime-versions: java: corretto11`** — the AL2 `standard:5.0` image's TLS
+   truststore + corretto11 resolves Maven Central; do not revert to `openjdk11` or an
+   older image.
+2. **An explicit `kubectl` install** — modern CodeBuild images do **not** bundle
+   `kubectl`. `k8-buildspec.yml` pins it:
+   ```yaml
+   - curl -sSLo /usr/local/bin/kubectl https://dl.k8s.io/release/v1.29.10/bin/linux/amd64/kubectl
+   - chmod +x /usr/local/bin/kubectl
+   - kubectl version --client      # note: no --short (removed in modern kubectl)
+   ```
+3. **`aws ecr get-login-password`** for the ECR login — AWS CLI v2 removed
+   `aws ecr get-login`:
+   ```yaml
+   - aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin ${REPOSITORY_URI%%/*}
+   ```
+
+Also keep the curated `-Dtest=...` filter (Section 1) so the load tests never run.
+
+---
+
+## 5. Background — why the image and runtime matter
+
+From roughly **July 2025 until 2026-06**, the prod deploy was **silently dead**. The
+`PubMedService` CodeBuild project ran on the deprecated **`aws/codebuild/standard:3.0`**
+image (Ubuntu 18.04, EOL). Its outdated TLS truststore could not authenticate to
+Maven Central, so `mvn clean install` failed with `Could not transfer artifact ...
+peer not authenticated` and the build exited non-zero. This was the long-standing
+"always-red AWS CodeBuild (PubMedService)" check on every `master` PR. Local builds
+(modern JDK 11 + cached `~/.m2`) succeeded, which masked the breakage.
+
+Consequence: live prod ran image tag
+`master-374.2025-07-03.04.48.11.c73d3492` — **July 2025 (commit `c73d349`)** *(as
+configured)* — so ~11 months of merges were undeployed.
+
+**Fix (2026-06):** the project image was switched to **`aws/codebuild/amazonlinux2-x86_64-standard:5.0`**
+(confirmed live) and the buildspecs were modernized in **PR #147** (`openjdk11` →
+`corretto11`, explicit pinned `kubectl` install, `aws ecr get-login` →
+`aws ecr get-login-password`). Dev was validated end-to-end (first successful deploy in
+~11 months); the prod catch-up was the deliberate follow-up gated on `mrj4001`.
+
+Takeaway for operators: **never downgrade the CodeBuild image or the buildspec
+runtime.** A green local build is not evidence the pipeline builds — verify the
+CodeBuild run itself (Section 6).
+
+---
+
+## 6. IaC caveat — the pipeline is NOT in CDK
+
+The deploy pipeline and the `PubMedService` CodeBuild project are **not** modeled by
+the current ReCiter-CDK. As configured, only the **ACM / ECR / S3 / RDS / Public**
+stacks are actually deployed from CDK; the CDK additionally models a **Fargate**
+architecture that is **not in use** (prod runs on EKS, not Fargate).
+
+Practical implications:
+
+- Make pipeline / CodeBuild changes via **AWS CLI or the console**, not by editing
+  CDK and running `cdk deploy`. A CDK deploy will not touch `PubMedService` and could
+  drift the Fargate model further from reality.
+- Because there is no IaC source of truth for these resources, **dump-before-edit**
+  (Section 4c) and re-verify after every change.
+- Record any manual change (image, env vars, buildspec branch logic) in project
+  memory so the next operator knows the live state.
+
+---
+
+## 7. Runtime verification (do this for parser / HTTP / deps / Boot changes)
+
+A build can be fully green while the live retrieval path is 100% broken (the EFetch
+DOCTYPE regression is the canonical example: every real NCBI EFetch response begins
+with `<!DOCTYPE PubmedArticleSet PUBLIC ...>`, which a DOCTYPE-disallowing SAX parser
+rejected → HTTP 500 on every query, with all unit tests still passing). For any change
+touching the SAX parser, HTTP client, dependencies, or the Spring Boot version,
+**runtime-verify** before approving a deploy.
+
+Local (JDK 11 required — Lombok 1.18.34 does not run on JDK 17+):
+
+```bash
+export JAVA_HOME=/opt/homebrew/opt/openjdk@11/libexec/openjdk.jdk/Contents/Home
+export PUBMED_API_KEY=<key>
+mvn -B -ntp clean package -DskipTests
+java -jar target/reciter-pubmed-retrieval-tool-1.1.0.jar --server.port=8083 &
+# Expect HTTP 200 with parsed articles (NOT a 500):
+curl -s 'http://localhost:8083/pubmed/ping'                       # -> Healthy
+curl -s 'http://localhost:8083/pubmed/query/Kukafka%20R%5Bau%5D' | head -c 400
+```
+
+Post-deploy (in-cluster), confirm a real query against the rolled pod, not just
+`/pubmed/ping`:
+
+```bash
+kubectl -n reciter exec deploy/reciter-pubmed-dev -c reciter-pubmed -- \
+  wget -qO- 'http://localhost:5000/pubmed/query/Kukafka%20R%5Bau%5D' | head -c 400
+```
+
+---
+
+## 8. Quick reference
+
+| Thing | Value |
+|-------|-------|
+| CodeBuild project | `PubMedService` (image `aws/codebuild/amazonlinux2-x86_64-standard:5.0`, buildspec `k8-buildspec.yml`) |
+| Dev pipeline | `ReCiter-Pubmed-Retrieval-Tool-Dev` (branch `dev`) — also `..._Dev_V2` exists |
+| Prod pipeline | `ReCiter-Pubmed-Retrieval-Tool-prod` (branch `master`) |
+| Pipeline stages | `Source → ManualApproval → Build` (Build does the deploy; no separate Deploy stage) |
+| Deployments | `reciter-pubmed-dev`, `reciter-pubmed-prod` (ns `reciter`, cluster `reciter`) |
+| Healthy pod | `2/2` (app + nginx sidecar); `GET /pubmed/ping` → `Healthy` |
+| CodeBuild env vars (preserve all 4) | `REPOSITORY_URI`, `EKS_KUBECTL_ROLE_ARN`, `EKS_CLUSTER_NAME`, `DOCKER_HUB_CREDENTIALS_ARN` |
+| Approval (non-hotfix prod) | `mrj4001` only; hotfixes fast-trackable; dev = agent/user |
+| Notification topic | `reciter-pipeline-validation` (subs: `paa2013@`, `szd2013@`; `mrj4001` NOT yet subscribed) |
+| Curated tests | `PubmedEFetchHandlerTest`, `PubMedUriParserCallableTest`, `PubMedArticleRetrievalServiceTest`; load test never run |
+| IaC | NOT in CDK — change via AWS CLI/console |

--- a/docs/rate-limiter-design-117.md
+++ b/docs/rate-limiter-design-117.md
@@ -1,0 +1,347 @@
+# Design: Shared cross-thread rate limiter and Retry-After on EFetch (Issue #117)
+
+**Status:** Design only. This document does **not** implement the change; issue #117 remains open.
+**Repo:** `wcmc-its/ReCiter-PubMed-Retrieval-Tool`
+**Runtime:** Java 11, Spring Boot 2.7.18 (`pom.xml:13,19`)
+**Scope of code reviewed:** `origin/dev` tip (worktree `docs/deploy-runbook-and-rate-limiter`, HEAD `7b1fada`).
+
+> **Important currency note.** Issue #117 was filed against `master` and cites line numbers
+> (`service:215-225`, `PubMedUriParserCallable uses raw URL.openStream()`) and a premise of
+> "high-volume EFetch **batches**." The code on `origin/dev` has since been refactored: there is
+> **no longer** an EFetch pagination loop or a work-stealing thread pool, and retrieval issues a
+> **single** EFetch per query. The *underlying gap* the issue describes (no shared rate limiter;
+> EFetch ignores rate-limit headers; per-request-only Retry-After; blocking sleep on a servlet
+> thread) is still real, just for a different concurrency reason (multiple pods + multiple
+> concurrent servlet requests, not intra-request batch fan-out). This document establishes
+> current behavior from the actual `origin/dev` code and re-frames the gap accordingly.
+
+---
+
+## 1. Current behavior (established from code)
+
+### 1.1 Retrieval flow — single EFetch, no batch fan-out, no thread pool
+
+`PubMedArticleRetrievalService.retrieve(String)` runs synchronously on the calling servlet thread:
+
+1. ESearch determines the matching count (`service:111-112`).
+2. If `count > RETRIEVAL_THRESHOLD` (2000, `service:54`) it hard-refuses with an `IOException`
+   (`service:114-116`) — mapped to HTTP 502 by `GlobalExceptionHandler` via the marker string
+   `"exceeded the threshold level"` (`GlobalExceptionHandler.java:29,34`).
+3. If `count == 0` it returns an empty list with no EFetch round-trip (`service:120-122`).
+4. Otherwise it builds **one** EFetch URL and runs **one** `PubMedUriParserCallable.call()`
+   synchronously, in-line, returning its result (`service:126-141`).
+
+The class javadoc states this explicitly: because the allowed count (2000) is well below
+`DEFAULT_RETMAX` (10000, `PubmedXmlQuery.java:11`), "every allowed query is satisfied by a single
+EFetch request — there is no need to paginate over retstart or fan the fetches out across a thread
+pool" (`service:99-105`).
+
+A repo-wide grep confirms this: there is **no** `ExecutorService`, `Executors.*`,
+`newWorkStealingPool`, `invokeAll`, or `submit(` anywhere under `src/main/java/`. The
+`PubMedUriParserCallable` still `implements Callable<...>` (`PubMedUriParserCallable.java:20`) but
+is now invoked directly via `.call()` on the servlet thread, not submitted to a pool.
+
+**Consequence for #117:** intra-request EFetch concurrency no longer exists. Concurrency that can
+collectively exceed the NCBI quota now comes from two other sources (see 1.5).
+
+### 1.2 Retry configuration (Spring `@Retryable`)
+
+`retrieve(...)` is annotated (`service:107-108`):
+
+```java
+@Retryable(maxAttempts = 7, value = IOException.class,
+    backoff = @Backoff(random = true, delay = 1500, maxDelay = 9000), listeners = {"retryListener"})
+```
+
+- **Attempts:** `maxAttempts = 7` (1 initial + 6 retries).
+- **Backoff:** randomized between `delay = 1500` ms and `maxDelay = 9000` ms per attempt
+  (`random = true`). This is the only inter-attempt wait; there is no exponential `multiplier`.
+- **Triggers on:** `IOException` only.
+- **Listener:** `RetryListener` (`RetryListener.java`) logs the retry count on each `onError`
+  (`RetryListener.java:24-27`); it does not alter backoff or honor any rate-limit signal.
+- **Recovery:** `@Recover recoverRetrieve(...)` re-throws the final `IOException` after attempts
+  are exhausted (`service:158-162`).
+- `@EnableRetry` is on `Application` (`Application.java:11`).
+
+This retry wraps the **whole** `retrieve` method (ESearch + EFetch). It reacts to thrown
+`IOException`s; it does **not** read NCBI rate-limit headers to decide its wait.
+
+### 1.3 Rate-limit / Retry-After handling — ESearch only, honored once, blocking
+
+Rate-limit handling exists **only on the ESearch path** and is invoked from `executeReadingBody`
+(`service:239-248`), which wraps the ESearch HTTP POST:
+
+```java
+try (CloseableHttpResponse response = pubMedHttpClient.execute(httppost)) {
+    if (shouldRetryAfterRateLimit(response, query)) {           // service:241
+        try (CloseableHttpResponse retryResponse = pubMedHttpClient.execute(httppost)) {
+            return readBody(retryResponse);
+        }
+    }
+    return readBody(response);
+}
+```
+
+`shouldRetryAfterRateLimit(...)` (`service:268-292`):
+
+- Reads `X-RateLimit-Limit`, `X-RateLimit-Remaining`, `Retry-After` headers (`service:269-271`),
+  fully null/length guarded because NCBI omits them on error pages.
+- Logs limit/remaining when both present (`service:273-276`).
+- If `X-RateLimit-Remaining == 0` **and** a `Retry-After` header is present, it
+  `Thread.sleep(Retry-After * 1000)` then returns `true` so the caller replays the request **once**
+  (`service:278-291`).
+
+Limitations of the current handling, all confirmed in code:
+
+- **ESearch-only.** EFetch does not call this path at all (see 1.4).
+- **Honored once.** A single replay; if the replay is also throttled the method returns the
+  throttled body (no second wait inside this method — only the outer `@Retryable` may re-enter).
+- **Blocking.** `Thread.sleep` runs on the servlet worker thread (`service:283`), tying up a Tomcat
+  thread for the full advertised interval.
+- **Per-request only.** The decision is local to one request/thread; nothing is shared across
+  threads or pods.
+
+### 1.4 EFetch fetch — raw connection, no header inspection
+
+EFetch is fetched inside `PubMedUriParserCallable.preprocessSpecialCharacters(...)`
+(`PubMedUriParserCallable.java:46-71`):
+
+```java
+URL url = new URL(inputSource.getSystemId());
+if (!EXPECTED_HOST.equalsIgnoreCase(url.getHost())) { ... }       // SSRF guard, line 50
+URLConnection connection = url.openConnection();                  // line 53
+connection.setConnectTimeout(CONNECT_TIMEOUT_MILLIS);             // 5_000, line 23/54
+connection.setReadTimeout(READ_TIMEOUT_MILLIS);                   // 60_000, line 26/55
+try (InputStream inputStream = connection.getInputStream()) {     // line 56
+    xml = new String(inputStream.readAllBytes(), StandardCharsets.UTF_8);
+}
+```
+
+- It uses a **raw `java.net.URLConnection`**, not the pooled `pubMedHttpClient`, and **never
+  inspects** `X-RateLimit-*` or `Retry-After` on the EFetch response.
+- It has an SSRF host guard (`EXPECTED_HOST = "www.ncbi.nlm.nih.gov"`,
+  `PubMedUriParserCallable.java:29,50`) and connect/read timeouts, but no throttling.
+- A 429/throttled EFetch surfaces only as an `IOException` from `getInputStream()` (e.g. HTTP 429),
+  which bubbles up to the outer `@Retryable` and is retried with the **random 1.5–9 s** backoff —
+  it does **not** read or honor the server's `Retry-After`.
+
+> The issue's phrase "PubMedUriParserCallable uses raw `URL.openStream()`" is directionally correct:
+> current code uses `url.openConnection().getInputStream()` (equivalent raw JDK fetch). The key
+> claim — EFetch ignores rate-limit headers — holds.
+
+### 1.5 Actual sources of concurrency against the shared NCBI key
+
+With batch fan-out gone, concurrent NCBI calls now come from:
+
+1. **Multiple concurrent servlet requests within one pod.** Each request runs ESearch + (up to one)
+   EFetch on its own Tomcat worker thread; the HTTP client pool allows up to
+   `MAX_TOTAL_CONNECTIONS = 50` / `MAX_CONNECTIONS_PER_ROUTE = 50` simultaneous connections to NCBI
+   (`HttpClientConfig.java:32-33`). Nothing throttles how many of those 50 fire per second.
+2. **Multiple pods.** `kubernetes/k8-deployment.yaml` defines an HPA with
+   `minReplicas: 1`, `maxReplicas: 4` (`k8-deployment.yaml:135-136`). Up to 4 pods can run
+   concurrently, each with its own 50-connection pool and its own local rate-limit view.
+3. **Other services sharing the same NCBI API key** (see 2.2).
+
+None of these coordinate. Each request, each pod, observes the per-key quota independently.
+
+---
+
+## 2. NCBI E-utilities limits
+
+> The following are NCBI's documented E-utilities policy limits, stated here as the constraint the
+> design must respect. They are not asserted from this repo's code; see the keyClaims list for the
+> verifier.
+
+- **Without an API key: 3 requests/second** per source.
+- **With an API key (`PUBMED_API_KEY`): 10 requests/second.** The key is read in
+  `PubmedXmlQuery` via `System.getenv("PUBMED_API_KEY")` (`PubmedXmlQuery.java:68`) and appended to
+  both ESearch and EFetch URLs (`PubmedXmlQuery.java:100-104,131-135`).
+- **The quota is enforced PER API KEY (or per source IP when no key is used), and is shared across
+  ALL usage of that key.** NCBI rate-limits the credential, not the process. Exceeding it returns
+  **HTTP 429** with a `Retry-After` header and `X-RateLimit-Remaining: 0`.
+
+### 2.2 The key is shared across multiple ReCiter services
+
+Per the workspace architecture, the same `PUBMED_API_KEY` is (or can be) used by more than one
+service that talks to NCBI — at minimum this PubMed Retrieval Tool, and potentially the main
+ReCiter app and the Scopus Retrieval Tool's NCBI usage. **A per-service limiter therefore cannot,
+by itself, guarantee the org stays under 10 req/s**, because it has no visibility into the other
+services' consumption of the same credential. (This cross-service sharing should be confirmed
+against actual deployment env config — see keyClaims.)
+
+---
+
+## 3. The gap (#117)
+
+| # | Gap | Evidence |
+|---|-----|----------|
+| G1 | **No shared rate limiter.** Each request/thread/pod observes the quota independently; nothing caps the aggregate request rate. | No limiter in code; `HttpClientConfig` allows 50 concurrent conns; HPA allows 4 pods. |
+| G2 | **EFetch ignores rate-limit headers entirely.** EFetch fetches via raw `URLConnection` and never reads `X-RateLimit-*` / `Retry-After`. | `PubMedUriParserCallable.java:53-58`. |
+| G3 | **Retry-After honored per-request only, and only on ESearch, only once.** | `service:241-247`, `service:268-292`. |
+| G4 | **Backoff blocks a servlet thread.** `Thread.sleep` on the Tomcat worker. | `service:283`. |
+| G5 | **`@Retryable` backoff is rate-limit-blind.** On a 429 it waits a random 1.5–9 s instead of the server-advertised `Retry-After`. | `service:107-108`. |
+| G6 | **Per-service scope may be insufficient.** The NCBI key is one budget shared across multiple services. | Section 2.2 (verify against env). |
+
+---
+
+## 4. Options
+
+All three options share a common, non-negotiable building block: **both ESearch and EFetch must
+acquire a permit before issuing their HTTP call, and both must honor a 429 `Retry-After` by
+returning that permit / suspending the limiter rather than immediately replaying.** They differ in
+*where the budget lives* and *who shares it*.
+
+### Option 1 — Per-pod in-process token bucket
+
+**Mechanism.** Add a single Spring-managed bean wrapping a token bucket — e.g. Guava
+`RateLimiter.create(permitsPerSecond)` or Resilience4j `RateLimiter` — sized to a **fraction** of
+the NCBI quota so that `pods × per-pod-rate ≤ key-quota`. With `maxReplicas: 4` and a 10 req/s key,
+each pod gets ~2 req/s (leaving headroom for other services). ESearch (`executeReadingBody`) and
+EFetch (`PubMedUriParserCallable`, which would need the bean injected instead of being a bare
+POJO) both `acquire()` before their call. On a 429, read `Retry-After` and `sleep`/`drain` the
+bucket for that interval before allowing the next acquire.
+
+**Honoring Retry-After.** Centralize the existing `shouldRetryAfterRateLimit` logic into the
+limiter: on `Remaining == 0` / 429, the limiter blocks all permit grants for `Retry-After` seconds.
+This makes EFetch honor Retry-After (closes G2/G3) and applies one coordinated wait per pod
+instead of each thread sleeping independently (mitigates, but does not eliminate, G4 — see cons).
+
+**Pros.**
+- No new infrastructure; pure in-process library. Lowest operational cost.
+- Closes G1 *within a pod*, G2, G3, G5 fully. Small, well-contained change.
+- Guava is already an indirect candidate; Resilience4j integrates cleanly with Spring Boot 2.7.
+
+**Cons / failure modes.**
+- **Does not coordinate across pods.** Correctness depends on the static fraction
+  (`per-pod-rate = key-quota / maxReplicas / safety-factor`). If the HPA scales beyond expectation,
+  or other services consume the key, the aggregate can still exceed quota (G1 partial, G6 open).
+- Static sizing wastes quota when fewer than `maxReplicas` pods are running.
+- If implemented with a blocking `acquire()`, still parks a servlet thread (G4 persists unless
+  paired with async handling; out of scope here).
+
+**Effort:** Small (~1–2 days). One bean, two call-site changes, sizing config, unit tests with a
+clock-injected limiter.
+
+### Option 2 — Shared cross-pod distributed rate limiter
+
+**Mechanism.** Put the token bucket in a store all pods share — ElastiCache **Redis** (atomic
+token-bucket via a Lua script / `bucket4j-redis`), or a **DynamoDB**-backed counter (atomic
+conditional updates on a per-second / sliding-window key). Every ESearch and EFetch acquires a
+permit from the shared bucket before calling NCBI, so all pods draw down **one** budget sized to the
+key quota (with headroom).
+
+**Honoring Retry-After.** On a 429 from NCBI, write the `Retry-After` deadline into the shared store
+(e.g. a `pausedUntil` timestamp). All pods consult it before acquiring and back off until it passes
+— so a throttle observed by *one* pod immediately throttles *all* pods. This is the only option that
+makes Retry-After genuinely cross-pod coordinated (closes G1, G2, G3, G4-coordination, G5).
+
+**Pros.**
+- True shared budget across all pods of *this service*; correct regardless of pod count.
+- Throttle signals propagate to every pod.
+
+**Cons / failure modes.**
+- **New infrastructure dependency** (ElastiCache or a DynamoDB table). Note DynamoDB SDK was
+  deliberately **excluded** from the build (`pom.xml` comment near line 92: "exclude the transitive
+  DynamoDB SDK so it is not bundled"), so DynamoDB would mean re-introducing a dependency that was
+  intentionally dropped.
+- **Per-call coordination latency** on the hot path (a Redis/Dynamo round-trip before every NCBI
+  call). For a service whose queries are small (≤2000 articles, single EFetch) this overhead may be
+  a meaningful fraction of total latency.
+- **Failure mode:** if the limiter store is unreachable, must choose fail-open (risk exceeding
+  quota) or fail-closed (block all NCBI traffic). Either is a new outage surface.
+- Still does not cover **other services** using the same key (G6 open) unless they share the same
+  store.
+
+**Effort:** Medium–Large (~1–2 weeks). New infra (CDK changes in ReCiter-CDK), client library,
+atomic-bucket logic, failure-mode policy, integration tests against a real store.
+
+### Option 3 — Org-level / per-API-key quota awareness
+
+**Mechanism.** Recognize that the unit of enforcement is the **API key**, shared across ReCiter,
+this tool, and the Scopus tool's NCBI usage. The limiter (token bucket + Retry-After pause state)
+is keyed by the API key and shared by **every** service that uses it — e.g. a shared Redis bucket
+namespaced by key, or a dedicated "NCBI gateway" service all NCBI traffic routes through that owns
+the single budget. This is Option 2 generalized to the org boundary.
+
+**Honoring Retry-After.** Identical to Option 2 but the `pausedUntil` / token state is global to the
+key, so a 429 seen by any service throttles all services using that key.
+
+**Pros.**
+- The **only** option that can actually guarantee the org stays under the NCBI per-key limit
+  (closes G6, and by extension G1 at the true boundary).
+- A single gateway centralizes Retry-After handling, logging, and key rotation.
+
+**Cons / failure modes.**
+- **Largest blast radius and coordination cost.** Requires changes/agreement across multiple repos
+  and teams; a shared gateway becomes a critical-path single point of failure for all NCBI traffic.
+- All of Option 2's infra and failure-mode concerns, amplified.
+- May be over-engineered if, in practice, this tool is the dominant consumer of the key (verify
+  actual key usage across services before committing).
+
+**Effort:** Large (multi-repo, multi-week). Cross-repo coordination (see `cross-repo` workflows),
+new shared component, ownership/on-call questions.
+
+---
+
+## 5. Comparison
+
+| Criterion | Opt 1 (per-pod bucket) | Opt 2 (cross-pod store) | Opt 3 (per-key/org) |
+|---|---|---|---|
+| Closes G1 (shared limiter) | Within a pod only | Across this service's pods | Across all services (true) |
+| Closes G2 (EFetch honors headers) | Yes | Yes | Yes |
+| Closes G3 (Retry-After cross-coordinated) | Per-pod | Cross-pod | Cross-service |
+| Handles unexpected pod scale-out | No (static fraction) | Yes | Yes |
+| Handles other services on same key | No | No | Yes |
+| New infrastructure | None | Redis or DynamoDB | Redis/gateway + multi-repo |
+| Hot-path latency cost | Negligible | Per-call round-trip | Per-call round-trip |
+| New failure surface | None | Limiter store | Gateway (critical path) |
+| Effort | Small (1–2 d) | Medium–Large (1–2 w) | Large (multi-week) |
+
+---
+
+## 6. Recommendation (phased)
+
+**Phase 0 — Unify and fix the header handling (do regardless of which budget model wins).**
+Extract the rate-limit/Retry-After logic out of `executeESearch`/`executeReadingBody` into a single
+collaborator consulted by **both** ESearch and EFetch. To do that, EFetch must first move off the
+raw `URLConnection` onto the pooled `pubMedHttpClient` (so it can read response headers) — or at
+minimum read the `URLConnection` headers it currently discards. Make `@Retryable`/the limiter honor
+the server's `Retry-After` on a 429 instead of the random 1.5–9 s backoff. This alone closes G2,
+G3, and G5 and is a prerequisite for every other phase. **Small effort; highest value-per-effort.**
+
+**Phase 1 — Ship Option 1 (per-pod in-process token bucket).** Add a Resilience4j (or Guava)
+limiter bean sized to `key-quota ÷ maxReplicas ÷ safety-factor` (e.g. 10 ÷ 4 ÷ ~1.2 ≈ 2 req/s/pod),
+made configurable via a property so it can be tuned without a rebuild. This gives correct behavior
+for the common case (≤4 pods, this tool as the main NCBI consumer) with **zero new
+infrastructure**. Document the static-sizing assumption as a known limitation.
+
+**Phase 2 — Promote to Option 2 (shared cross-pod limiter) only if measured 429s persist** after
+Phase 1, or if the service routinely runs near `maxReplicas`. Prefer **Redis/ElastiCache** over
+DynamoDB to avoid re-introducing the deliberately-excluded DynamoDB SDK. Define the fail-open vs
+fail-closed policy up front.
+
+**Phase 3 — Option 3 (org-level) only with cross-team commitment** and after confirming the actual
+distribution of NCBI key usage across services. Treat it as a coordinated multi-repo initiative, not
+a change to this repo alone. If this tool turns out to be the dominant consumer, Phase 3 may never be
+necessary.
+
+**Rationale.** The biggest correctness defect with the smallest fix is the unified Phase 0 header
+handling — it makes EFetch honor Retry-After and stops the rate-limit-blind backoff. Phase 1 then
+caps aggregate rate cheaply and correctly for the realistic deployment (HPA max 4). The expensive,
+infra-bearing options (2 and 3) are justified only by *evidence* (observed 429s, real multi-service
+contention), so they are deferred behind measurement rather than built speculatively.
+
+---
+
+## 7. Out of scope / open questions for the verifier
+
+- Confirm NCBI's current published limits (3/s no key, 10/s with key) and that the quota is
+  per-key/per-source — these are stated from policy, not from repo code.
+- Confirm whether `PUBMED_API_KEY` is actually the **same** key used by the main ReCiter app and the
+  Scopus tool in the deployed environment (determines whether G6 / Option 3 is real).
+- Async (non-blocking) request handling to fully eliminate G4 (servlet-thread blocking) is a larger
+  architectural change and is intentionally left out of this design.
+
+---
+
+*Design only — no code changed. Issue #117 stays open.*

--- a/kubernetes/k8-configmap.yaml
+++ b/kubernetes/k8-configmap.yaml
@@ -64,7 +64,7 @@ data:
             proxy_connect_timeout 300s;
         }
 
-        location /pubmed/v2 {
+        location /pubmed/v3 {
             rewrite ^/pubmed/(.*)$ /$1 break;
             proxy_pass http://localhost:5000;
             proxy_redirect off;

--- a/nginx/conf.d/reciter-pubmed.conf
+++ b/nginx/conf.d/reciter-pubmed.conf
@@ -56,7 +56,7 @@ server {
             proxy_connect_timeout 300s;
         }
 
-        location /pubmed/v2 {
+        location /pubmed/v3 {
             rewrite ^/pubmed/(.*)$ /$1 break;
             proxy_pass http://app:5000;
             proxy_redirect off;

--- a/pom.xml
+++ b/pom.xml
@@ -34,25 +34,9 @@
             <artifactId>squiggly-filter-jackson</artifactId>
             <version>1.3.18</version>
         </dependency>
-        <!-- Jackson pinned to the latest patched 2.12.x to clear known CVEs while staying on the
-             2.12 line (binary-compatible with Spring Boot 2.5's managed Jackson). databind 2.12.7.1
-             is the security hotfix on top of the 2.12.7 core/annotations. -->
-        <!-- https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-annotations -->
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-annotations</artifactId>
-            <version>2.12.7</version>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-core</artifactId>
-            <version>2.12.7</version>
-        </dependency>
-        <dependency>
-		    <groupId>com.fasterxml.jackson.core</groupId>
-		    <artifactId>jackson-databind</artifactId>
-		    <version>2.12.7.1</version>
-		</dependency>
+        <!-- Jackson is managed by the Spring Boot 2.7 BOM (currently 2.13.x), which supersedes the
+             explicit 2.12.x CVE pins that were required under Boot 2.5. Do not re-pin Jackson here:
+             bump Spring Boot to move Jackson, so the whole stack stays version-aligned. -->
         <dependency>
 			<groupId>io.springfox</groupId>
 			<artifactId>springfox-boot-starter</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,22 @@
         <java.version>11</java.version>
     </properties>
 
+    <dependencyManagement>
+        <dependencies>
+            <!-- Pin swagger-models to the version springdoc-openapi 1.8.0's swagger-core (2.2.20)
+                 expects. The reciter-pubmed-model dependency transitively drags in the unused
+                 swagger-codegen maven plugin, which forces the ancient swagger-models 2.0.0; that
+                 old version is missing classes springdoc references and breaks startup (#120).
+                 Pinning here (rather than excluding swagger-codegen) avoids disturbing other
+                 libraries the build picks up transitively through that same chain. -->
+            <dependency>
+                <groupId>io.swagger.core.v3</groupId>
+                <artifactId>swagger-models</artifactId>
+                <version>2.2.20</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -37,11 +53,15 @@
         <!-- Jackson is managed by the Spring Boot 2.7 BOM (currently 2.13.x), which supersedes the
              explicit 2.12.x CVE pins that were required under Boot 2.5. Do not re-pin Jackson here:
              bump Spring Boot to move Jackson, so the whole stack stays version-aligned. -->
+        <!-- OpenAPI/Swagger UI via springdoc-openapi (replaces the abandoned Springfox 3.0.0, #120).
+             1.8.0 is the last 1.x release and the one compatible with Spring Boot 2.7 / javax;
+             springdoc 2.x requires Spring Boot 3 / jakarta and is the upgrade target for epic #136.
+             Serves Swagger UI at /swagger-ui/index.html and the OpenAPI JSON at /v3/api-docs. -->
         <dependency>
-			<groupId>io.springfox</groupId>
-			<artifactId>springfox-boot-starter</artifactId>
-			<version>3.0.0</version>
-		</dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-ui</artifactId>
+            <version>1.8.0</version>
+        </dependency>
         <!-- https://mvnrepository.com/artifact/org.projectlombok/lombok -->
         <dependency>
             <groupId>org.projectlombok</groupId>

--- a/src/main/java/reciter/controller/PingController.java
+++ b/src/main/java/reciter/controller/PingController.java
@@ -1,8 +1,8 @@
 package reciter.controller;
 
 
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiOperation;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -11,10 +11,10 @@ import org.springframework.web.bind.annotation.ResponseBody;
 
 @Controller
 @RequestMapping("/pubmed")
-@Api(value = "PingController", description = "Health Check.")
+@Tag(name = "Ping Controller", description = "Health Check.")
 public class PingController {
 
-    @ApiOperation(value = "Health check", response = ResponseEntity.class)
+    @Operation(summary = "Health check")
     @RequestMapping(value = "/ping", method = RequestMethod.GET, produces = "text/plain")
     @ResponseBody
     public ResponseEntity<String> ping() {

--- a/src/main/java/reciter/controller/PubMedRetrievalToolController.java
+++ b/src/main/java/reciter/controller/PubMedRetrievalToolController.java
@@ -22,10 +22,10 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiResponse;
-import io.swagger.annotations.ApiResponses;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.extern.slf4j.Slf4j;
 import reciter.model.pubmed.PubMedArticle;
 import reciter.pubmed.model.PubMedQuery;
@@ -34,18 +34,18 @@ import reciter.pubmed.retriever.PubMedArticleRetrievalService;
 @Slf4j
 @Controller
 @RequestMapping("/pubmed")
-@Api(value = "PubMedController", description = "Operations on querying the PubMed API.")
+@Tag(name = "PubMed Controller", description = "Operations on querying the PubMed API.")
 public class PubMedRetrievalToolController {
 
     @Autowired
     private PubMedArticleRetrievalService pubMedArticleRetrievalService;
 
-    @ApiOperation(value = "Query with field selection.", response = List.class)
+    @Operation(summary = "Query with field selection.")
     @ApiResponses(value = {
-            @ApiResponse(code = 200, message = "Successfully retrieved list"),
-            @ApiResponse(code = 401, message = "You are not authorized to view the resource"),
-            @ApiResponse(code = 403, message = "Accessing the resource you were trying to reach is forbidden"),
-            @ApiResponse(code = 404, message = "The resource you were trying to reach is not found")
+            @ApiResponse(responseCode = "200", description = "Successfully retrieved list"),
+            @ApiResponse(responseCode = "401", description = "You are not authorized to view the resource"),
+            @ApiResponse(responseCode = "403", description = "Accessing the resource you were trying to reach is forbidden"),
+            @ApiResponse(responseCode = "404", description = "The resource you were trying to reach is not found")
     })
     @RequestMapping(value = "/query/{query}", method = RequestMethod.GET, produces = "application/json")
     @ResponseBody

--- a/src/main/java/reciter/pubmed/callable/PubMedUriParserCallable.java
+++ b/src/main/java/reciter/pubmed/callable/PubMedUriParserCallable.java
@@ -4,14 +4,15 @@ import lombok.AllArgsConstructor;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 import reciter.model.pubmed.PubMedArticle;
+import reciter.pubmed.ratelimit.NcbiRateLimiter;
 import reciter.pubmed.xmlparser.PubmedEFetchHandler;
 
 import javax.xml.parsers.SAXParser;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringReader;
+import java.net.HttpURLConnection;
 import java.net.URL;
-import java.net.URLConnection;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.concurrent.Callable;
@@ -28,9 +29,14 @@ public class PubMedUriParserCallable implements Callable<List<PubMedArticle>> {
     /** Only the NCBI E-utilities host may be fetched (SSRF guard on the SAX system-id). */
     private static final String EXPECTED_HOST = "www.ncbi.nlm.nih.gov";
 
+    /** HTTP 429 (Too Many Requests) — no constant for it on {@link HttpURLConnection} in Java 11. */
+    private static final int HTTP_TOO_MANY_REQUESTS = 429;
+
     private final PubmedEFetchHandler xmlHandler;
     private final SAXParser saxParser;
     private final InputSource inputSource;
+    /** Per-pod NCBI rate limiter (issue #117). May be {@code null} in pure unit tests. */
+    private final NcbiRateLimiter rateLimiter;
 
     public List<PubMedArticle> parse(InputSource inputSource) throws SAXException, IOException {
         //inputSource = preprocessSpecialCharacters(inputSource);
@@ -50,9 +56,26 @@ public class PubMedUriParserCallable implements Callable<List<PubMedArticle>> {
             if (!EXPECTED_HOST.equalsIgnoreCase(url.getHost())) {
                 throw new IOException("Refusing to fetch EFetch XML from unexpected host: " + url.getHost());
             }
-            URLConnection connection = url.openConnection();
+            HttpURLConnection connection = (HttpURLConnection) url.openConnection();
             connection.setConnectTimeout(CONNECT_TIMEOUT_MILLIS);
             connection.setReadTimeout(READ_TIMEOUT_MILLIS);
+            // Honor the per-pod NCBI budget before issuing the EFetch request (issue #117).
+            if (rateLimiter != null) {
+                rateLimiter.acquire();
+            }
+            int status = connection.getResponseCode();
+            if (status == HTTP_TOO_MANY_REQUESTS || status == HttpURLConnection.HTTP_UNAVAILABLE) {
+                // EFetch was throttled. Read the server's Retry-After, pause the shared limiter so
+                // every other in-pod request backs off too, and surface an IOException so the
+                // outer @Retryable re-enters retrieve() (whose next acquire() waits out the pause).
+                long retryAfterSeconds = parseRetryAfterSeconds(connection.getHeaderField("Retry-After"));
+                if (rateLimiter != null) {
+                    rateLimiter.pauseFor(retryAfterSeconds);
+                }
+                connection.disconnect();
+                throw new IOException("EFetch throttled by NCBI (HTTP " + status
+                        + "), Retry-After=" + retryAfterSeconds + "s");
+            }
             try (InputStream inputStream = connection.getInputStream()) {
                 xml = new String(inputStream.readAllBytes(), StandardCharsets.UTF_8);
             }
@@ -68,5 +91,24 @@ public class PubMedUriParserCallable implements Callable<List<PubMedArticle>> {
         xml = xml.replace("<b>", "&lt;b&gt;");
         xml = xml.replace("</b>", "&lt;/b&gt;");
         return new InputSource(new StringReader(xml));
+    }
+
+    /**
+     * Parses an NCBI {@code Retry-After} header (delta-seconds form). Returns a 1-second floor when
+     * the header is absent or not an integer (NCBI uses delta-seconds, not the HTTP-date form), so a
+     * throttled response always produces some back-off rather than a tight retry loop.
+     */
+    private static long parseRetryAfterSeconds(String headerValue) {
+        if (headerValue != null) {
+            try {
+                long seconds = Long.parseLong(headerValue.trim());
+                if (seconds > 0) {
+                    return seconds;
+                }
+            } catch (NumberFormatException ignored) {
+                // Fall through to the default floor below.
+            }
+        }
+        return 1L;
     }
 }

--- a/src/main/java/reciter/pubmed/ratelimit/NcbiRateLimiter.java
+++ b/src/main/java/reciter/pubmed/ratelimit/NcbiRateLimiter.java
@@ -1,0 +1,128 @@
+package reciter.pubmed.ratelimit;
+
+import java.util.concurrent.TimeUnit;
+import java.util.function.LongSupplier;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Per-pod, in-process rate limiter for outbound NCBI E-utilities calls (issue #117, Phase 1).
+ *
+ * <p>NCBI enforces its request quota <em>per API key</em> — 10 req/s with a key, 3 req/s without —
+ * shared across every process that uses that key. With this service horizontally scaled (the HPA
+ * allows up to 4 pods) and a 50-connection HTTP pool per pod, nothing previously capped how fast
+ * the service issued NCBI requests, so concurrent servlet requests could collectively exceed the
+ * quota and earn HTTP 429s. This limiter smooths each pod to a configurable fraction of the key
+ * quota ({@code pubmed.ratelimit.permits-per-second}, default 2.0 ≈ 10/s ÷ 4 pods ÷ headroom) so
+ * the aggregate across the expected pod count stays under the per-key limit.
+ *
+ * <p>It is a single shared bean: {@link #acquire()} is called before <em>both</em> the ESearch POST
+ * and the EFetch GET, so all in-pod NCBI traffic draws from one budget. When NCBI signals throttling
+ * (HTTP 429 / {@code X-RateLimit-Remaining: 0} with a {@code Retry-After}), {@link #pauseFor(long)}
+ * suspends <em>all</em> permit grants in this pod until the advertised interval passes — so a
+ * throttle observed by one request immediately backs off every other request in the pod, instead of
+ * each thread sleeping independently.
+ *
+ * <p>This is the per-pod (Option 1) phase of {@code docs/rate-limiter-design-117.md}. Cross-pod
+ * coordination (Options 2/3) is deliberately out of scope: correctness here depends on the static
+ * sizing {@code permits-per-second ≈ key-quota ÷ maxReplicas ÷ safety-factor}.
+ */
+@Slf4j
+@Component
+public class NcbiRateLimiter {
+
+    private final boolean enabled;
+    private final long intervalNanos;     // minimum spacing between successive permits
+    private final LongSupplier nanoClock; // seam for tests; defaults to System::nanoTime
+    private final Sleeper sleeper;        // seam for tests; defaults to TimeUnit.NANOSECONDS.sleep
+
+    /** Earliest time (nanoClock domain) at which the next permit may be granted. Guarded by {@code this}. */
+    private long nextPermitNanos = Long.MIN_VALUE;
+
+    /** Indirection over the actual blocking wait so tests can run without real time passing. */
+    @FunctionalInterface
+    interface Sleeper {
+        void sleepNanos(long nanos) throws InterruptedException;
+    }
+
+    @Autowired
+    public NcbiRateLimiter(
+            @Value("${pubmed.ratelimit.permits-per-second:2.0}") double permitsPerSecond,
+            @Value("${pubmed.ratelimit.enabled:true}") boolean enabled) {
+        this(permitsPerSecond, enabled, System::nanoTime, defaultSleeper());
+    }
+
+    /** Seam constructor: inject the clock and sleeper for deterministic unit tests. */
+    NcbiRateLimiter(double permitsPerSecond, boolean enabled, LongSupplier nanoClock, Sleeper sleeper) {
+        if (permitsPerSecond <= 0) {
+            throw new IllegalArgumentException(
+                    "pubmed.ratelimit.permits-per-second must be > 0, was " + permitsPerSecond);
+        }
+        this.enabled = enabled;
+        this.nanoClock = nanoClock;
+        this.sleeper = sleeper;
+        this.intervalNanos = (long) (TimeUnit.SECONDS.toNanos(1) / permitsPerSecond);
+        if (enabled) {
+            log.info("NCBI rate limiter enabled: {} permit(s)/sec ({} ms spacing).",
+                    permitsPerSecond, TimeUnit.NANOSECONDS.toMillis(intervalNanos));
+        } else {
+            log.info("NCBI rate limiter disabled (pubmed.ratelimit.enabled=false).");
+        }
+    }
+
+    private static Sleeper defaultSleeper() {
+        return nanos -> {
+            if (nanos > 0) {
+                TimeUnit.NANOSECONDS.sleep(nanos);
+            }
+        };
+    }
+
+    /**
+     * Blocks until a permit is available — respecting both the steady-state rate and any active
+     * {@link #pauseFor(long) Retry-After pause} — then returns. A no-op when disabled. The wait is
+     * computed under the lock but performed outside it, so a sleeping caller never blocks others
+     * from reserving their own (later) slots.
+     */
+    public void acquire() {
+        if (!enabled) {
+            return;
+        }
+        long waitNanos;
+        synchronized (this) {
+            long now = nanoClock.getAsLong();
+            long grantAt = Math.max(now, nextPermitNanos);
+            waitNanos = grantAt - now;
+            nextPermitNanos = grantAt + intervalNanos;
+        }
+        if (waitNanos > 0) {
+            try {
+                sleeper.sleepNanos(waitNanos);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                log.warn("Interrupted while waiting for an NCBI rate-limit permit.", e);
+            }
+        }
+    }
+
+    /**
+     * Suspends all permit grants until at least {@code retryAfterSeconds} from now, honoring an NCBI
+     * {@code Retry-After}. Safe to call from any thread; the longest pause wins. A no-op when
+     * disabled or given a non-positive interval.
+     */
+    public synchronized void pauseFor(long retryAfterSeconds) {
+        if (!enabled || retryAfterSeconds <= 0) {
+            return;
+        }
+        long resumeAt = nanoClock.getAsLong() + TimeUnit.SECONDS.toNanos(retryAfterSeconds);
+        if (resumeAt > nextPermitNanos) {
+            nextPermitNanos = resumeAt;
+            log.warn("NCBI throttling observed; pausing all outbound NCBI requests in this pod for {}s (Retry-After).",
+                    retryAfterSeconds);
+        }
+    }
+}

--- a/src/main/java/reciter/pubmed/retriever/PubMedArticleRetrievalService.java
+++ b/src/main/java/reciter/pubmed/retriever/PubMedArticleRetrievalService.java
@@ -37,6 +37,7 @@ import reciter.model.pubmed.PubMedArticle;
 import reciter.pubmed.callable.PubMedUriParserCallable;
 import reciter.pubmed.model.PubmedESearchResult;
 import reciter.pubmed.querybuilder.PubmedXmlQuery;
+import reciter.pubmed.ratelimit.NcbiRateLimiter;
 import reciter.pubmed.xmlparser.PubmedEFetchHandler;
 
 @Slf4j
@@ -57,6 +58,10 @@ public class PubMedArticleRetrievalService {
 
     @Autowired
     private CloseableHttpClient pubMedHttpClient;
+
+    /** Per-pod NCBI rate limiter (issue #117); acquired before every ESearch and EFetch call. */
+    @Autowired
+    private NcbiRateLimiter rateLimiter;
 
     /*@Autowired
     private SAXParser saxParser;
@@ -137,7 +142,7 @@ public class PubMedArticleRetrievalService {
 
         try {
             PubMedUriParserCallable callable =
-                    new PubMedUriParserCallable(new PubmedEFetchHandler(), getSaxParser(), new InputSource(eFetchUrl));
+                    new PubMedUriParserCallable(new PubmedEFetchHandler(), getSaxParser(), new InputSource(eFetchUrl), rateLimiter);
             return new ArrayList<>(callable.call());
         } catch (IOException e) {
             throw e;
@@ -237,8 +242,12 @@ public class PubMedArticleRetrievalService {
      * Response entities are always closed via try-with-resources.
      */
     private String executeReadingBody(HttpPost httppost, String query) throws IOException {
+        rateLimiter.acquire();
         try (CloseableHttpResponse response = pubMedHttpClient.execute(httppost)) {
             if (shouldRetryAfterRateLimit(response, query)) {
+                // shouldRetryAfterRateLimit has paused the shared limiter for the advertised
+                // Retry-After; this acquire() waits it out before replaying the request once.
+                rateLimiter.acquire();
                 try (CloseableHttpResponse retryResponse = pubMedHttpClient.execute(httppost)) {
                     return readBody(retryResponse);
                 }
@@ -260,10 +269,12 @@ public class PubMedArticleRetrievalService {
     }
 
     /**
-     * Inspects the NCBI rate-limit response headers. Returns {@code true} (after sleeping for the
-     * advertised Retry-After interval) when the remaining quota is exhausted and the caller should
-     * replay the request. Header access is fully null/length guarded because NCBI omits these
-     * headers on error pages.
+     * Inspects the NCBI rate-limit response headers. When the remaining quota is exhausted
+     * (X-RateLimit-Remaining == 0) and a Retry-After header is present, it pauses the shared
+     * {@link NcbiRateLimiter} for the advertised interval — so every in-pod request backs off, not
+     * just this thread — and returns {@code true} so the caller replays the request once (its
+     * {@link NcbiRateLimiter#acquire()} waits the pause out). Header access is fully null/length
+     * guarded because NCBI omits these headers on error pages.
      */
     private boolean shouldRetryAfterRateLimit(CloseableHttpResponse response, String query) {
         Header[] headerRateLimitRemaining = response.getHeaders("X-RateLimit-Remaining");
@@ -280,10 +291,10 @@ public class PubMedArticleRetrievalService {
             if (headerRetryAfter != null && headerRetryAfter.length > 0 && headerRetryAfter[0] != null) {
                 log.info("Query=[{}] {}", query, headerRetryAfter[0].toString());
                 try {
-                    Thread.sleep(Long.parseLong(headerRetryAfter[0].getValue()) * 1000L);
-                } catch (InterruptedException e) {
-                    log.error("InterruptedException", e);
-                    Thread.currentThread().interrupt();
+                    rateLimiter.pauseFor(Long.parseLong(headerRetryAfter[0].getValue()));
+                } catch (NumberFormatException e) {
+                    log.warn("Unparseable Retry-After header value [{}] for query=[{}]; skipping pause.",
+                            headerRetryAfter[0].getValue(), query);
                 }
                 return true;
             }

--- a/src/main/java/reciter/swagger/SwaggerConfig.java
+++ b/src/main/java/reciter/swagger/SwaggerConfig.java
@@ -3,36 +3,34 @@ package reciter.swagger;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-import springfox.documentation.builders.ApiInfoBuilder;
-import springfox.documentation.builders.RequestHandlerSelectors;
-import springfox.documentation.service.ApiInfo;
-import springfox.documentation.service.Contact;
-import springfox.documentation.spi.DocumentationType;
-import springfox.documentation.spring.web.plugins.Docket;
-import springfox.documentation.swagger2.annotations.EnableSwagger2;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Contact;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.info.License;
 
-import static springfox.documentation.builders.PathSelectors.regex;
-
+/**
+ * OpenAPI/Swagger configuration via springdoc-openapi (#120, replacing the abandoned Springfox).
+ *
+ * <p>springdoc auto-detects the controller request mappings, so no Docket/path selection is needed:
+ * every endpoint in this service is under {@code /pubmed}. This bean only supplies the API metadata.
+ * Swagger UI is served at {@code /swagger-ui/index.html} and the OpenAPI JSON at {@code /v3/api-docs}.
+ */
 @Configuration
-@EnableSwagger2
 public class SwaggerConfig {
-    @Bean
-    public Docket productApi() {
-        return new Docket(DocumentationType.SWAGGER_2)
-                .select()
-                .apis(RequestHandlerSelectors.basePackage("reciter.controller"))
-                .paths(regex("/pubmed.*"))
-                .build()
-                .apiInfo(apiInfo());
-    }
 
-    private ApiInfo apiInfo() {
-        return new ApiInfoBuilder().title("ReCiter publication management system - PubMed Retrieval Tool")
-                .description("Retrieve publications and publication counts from PubMed. More info here: https://github.com/wcmc-its/ReCiter-PubMed-Retrieval-Tool/").termsOfServiceUrl("")
-                .contact(new Contact("Paul J. Albert", "https://github.com/wcmc-its/ReCiter", "paa2013@med.cornell.edu"))
-                .license("Apache License Version 2.0")
-                .licenseUrl("https://www.apache.org/licenses/LICENSE-2.0")
+    @Bean
+    public OpenAPI pubMedRetrievalToolOpenAPI() {
+        return new OpenAPI().info(new Info()
+                .title("ReCiter publication management system - PubMed Retrieval Tool")
+                .description("Retrieve publications and publication counts from PubMed. More info here: "
+                        + "https://github.com/wcmc-its/ReCiter-PubMed-Retrieval-Tool/")
                 .version("1.1.0")
-                .build();
+                .contact(new Contact()
+                        .name("Paul J. Albert")
+                        .url("https://github.com/wcmc-its/ReCiter")
+                        .email("paa2013@med.cornell.edu"))
+                .license(new License()
+                        .name("Apache License Version 2.0")
+                        .url("https://www.apache.org/licenses/LICENSE-2.0")));
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -4,6 +4,14 @@ server.port=5000
 # Springfox 3.0.0. Keep the legacy AntPathMatcher so Swagger/Springfox loads.
 spring.mvc.pathmatch.matching-strategy=ANT_PATH_MATCHER
 
+# NCBI E-utilities per-pod rate limiter (issue #117). NCBI enforces its quota per API key
+# (~10 req/s with a key, 3 req/s without), shared across every process using that key. Each pod
+# is smoothed to a fraction of that budget so pods x rate stays under quota (the HPA allows up to
+# 4 pods, so ~2/s/pod leaves headroom for retries and other services on the same key). Tune these
+# without a rebuild; set pubmed.ratelimit.enabled=false to disable entirely (e.g. local dev).
+pubmed.ratelimit.permits-per-second=2.0
+pubmed.ratelimit.enabled=true
+
 # Logging goes to stdout/console only (see logback-spring.xml) so it is collected
 # into CloudWatch from the container's stdout on EKS (Fluent Bit / Container Insights).
 # File logging is intentionally NOT configured: an in-container log file is ephemeral

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,9 +1,5 @@
 server.port=5000
 
-# Spring Boot 2.6+ defaults to PATH_PATTERN_PARSER, which fails at startup with
-# Springfox 3.0.0. Keep the legacy AntPathMatcher so Swagger/Springfox loads.
-spring.mvc.pathmatch.matching-strategy=ANT_PATH_MATCHER
-
 # NCBI E-utilities per-pod rate limiter (issue #117). NCBI enforces its quota per API key
 # (~10 req/s with a key, 3 req/s without), shared across every process using that key. Each pod
 # is smoothed to a fraction of that budget so pods x rate stays under quota (the HPA allows up to

--- a/src/test/java/reciter/pubmed/callable/PubMedUriParserCallableTest.java
+++ b/src/test/java/reciter/pubmed/callable/PubMedUriParserCallableTest.java
@@ -5,6 +5,7 @@ import org.testng.annotations.Test;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 import reciter.model.pubmed.PubMedArticle;
+import reciter.pubmed.ratelimit.NcbiRateLimiter;
 import reciter.pubmed.xmlparser.PubmedEFetchHandler;
 
 import javax.xml.parsers.SAXParser;
@@ -37,7 +38,10 @@ public class PubMedUriParserCallableTest {
     public void testInvalidCharacterParse() throws Exception {
         File initialFile = new File("src/test/resources/reciter/pubmed/callable/28356292.xml");
         inputSource = new InputSource(new FileInputStream(initialFile));
-        pubMedUriParserCallable = new PubMedUriParserCallable(xmlHandler, saxParser, inputSource);
+        // This fixture parses a local file (systemId is null), so the rate limiter is never
+        // exercised; pass a disabled one to satisfy the constructor.
+        NcbiRateLimiter rateLimiter = new NcbiRateLimiter(2.0, false);
+        pubMedUriParserCallable = new PubMedUriParserCallable(xmlHandler, saxParser, inputSource, rateLimiter);
         List<PubMedArticle> pubMedArticles = pubMedUriParserCallable.call();
         PubMedArticle pubMedArticle = pubMedArticles.get(0);
         String articleTitle = pubMedArticle.getMedlinecitation().getArticle().getArticletitle();

--- a/src/test/java/reciter/pubmed/ratelimit/NcbiRateLimiterTest.java
+++ b/src/test/java/reciter/pubmed/ratelimit/NcbiRateLimiterTest.java
@@ -1,0 +1,106 @@
+package reciter.pubmed.ratelimit;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+/**
+ * Deterministic unit tests for {@link NcbiRateLimiter}. A fake clock and a fake sleeper (which
+ * advances that clock instead of actually sleeping) make the limiter's timing fully testable with
+ * no wall-clock waits.
+ */
+public class NcbiRateLimiterTest {
+
+    /** Fake monotonic clock, in nanoseconds. */
+    private final long[] nowNanos = {0L};
+    /** Records every requested sleep (ns); a sleep advances the fake clock by that amount. */
+    private final List<Long> sleeps = new ArrayList<>();
+
+    // TestNG reuses one instance across @Test methods and does not reset fields between them, so
+    // reset the fake clock and recorded sleeps before each test to keep them independent.
+    @BeforeMethod
+    public void resetClock() {
+        nowNanos[0] = 0L;
+        sleeps.clear();
+    }
+
+    private NcbiRateLimiter limiter(double permitsPerSecond, boolean enabled) {
+        return new NcbiRateLimiter(permitsPerSecond, enabled,
+                () -> nowNanos[0],
+                nanos -> { sleeps.add(nanos); nowNanos[0] += nanos; });
+    }
+
+    private static long millisToNanos(long millis) {
+        return TimeUnit.MILLISECONDS.toNanos(millis);
+    }
+
+    @Test
+    public void firstPermitIsImmediateThenSpacedAtTheConfiguredRate() {
+        NcbiRateLimiter limiter = limiter(2.0, true); // 2/s => 500ms spacing
+
+        limiter.acquire(); // #1 immediate
+        limiter.acquire(); // #2 waits one interval
+        limiter.acquire(); // #3 waits another interval
+
+        assertEquals(sleeps.size(), 2, "Only the 2nd and 3rd acquires should wait; the first is immediate");
+        assertEquals((long) sleeps.get(0), millisToNanos(500), "2nd permit must wait one 500ms interval");
+        assertEquals((long) sleeps.get(1), millisToNanos(500), "3rd permit must wait one more 500ms interval");
+    }
+
+    @Test
+    public void pauseForMakesTheNextAcquireWaitOutTheRetryAfter() {
+        NcbiRateLimiter limiter = limiter(2.0, true);
+
+        limiter.acquire();      // #1 immediate, advances next permit by 500ms
+        limiter.pauseFor(3);    // Retry-After: 3s — must dominate the 500ms spacing
+        limiter.acquire();      // #2 must wait ~3s
+
+        assertEquals(sleeps.size(), 1, "Only the post-pause acquire should sleep");
+        assertEquals((long) sleeps.get(0), TimeUnit.SECONDS.toNanos(3),
+                "After pauseFor(3) the next permit must wait the full 3s Retry-After");
+    }
+
+    @Test
+    public void longestPauseWins() {
+        NcbiRateLimiter limiter = limiter(100.0, true); // tiny spacing so pauses dominate
+
+        limiter.pauseFor(2);
+        limiter.pauseFor(5);
+        limiter.pauseFor(1); // shorter than the already-set 5s pause; must not shorten it
+        limiter.acquire();
+
+        assertEquals((long) sleeps.get(0), TimeUnit.SECONDS.toNanos(5),
+                "The longest outstanding pause must win");
+    }
+
+    @Test
+    public void disabledLimiterNeverWaits() {
+        NcbiRateLimiter limiter = limiter(2.0, false);
+
+        for (int i = 0; i < 5; i++) {
+            limiter.acquire();
+        }
+        limiter.pauseFor(10);
+        limiter.acquire();
+
+        assertTrue(sleeps.isEmpty(), "A disabled limiter must never sleep or pause");
+    }
+
+    @Test
+    public void nonPositiveRateIsRejected() {
+        try {
+            limiter(0.0, true);
+            fail("Expected IllegalArgumentException for a non-positive rate");
+        } catch (IllegalArgumentException expected) {
+            assertTrue(expected.getMessage().contains("permits-per-second"),
+                    "Message should name the offending property");
+        }
+    }
+}

--- a/src/test/java/reciter/pubmed/xmlparser/PubmedEFetchHandlerTest.java
+++ b/src/test/java/reciter/pubmed/xmlparser/PubmedEFetchHandlerTest.java
@@ -18,14 +18,18 @@ import org.xml.sax.InputSource;
 import lombok.extern.slf4j.Slf4j;
 import reciter.model.pubmed.PubMedArticle;
 import reciter.pubmed.callable.PubMedUriParserCallable;
+import reciter.pubmed.ratelimit.NcbiRateLimiter;
 
 @Slf4j
 public class PubmedEFetchHandlerTest {
-	
+
 	private PubmedEFetchHandler xmlHandler;
     private SAXParser saxParser;
     private InputSource inputSource;
     private PubMedUriParserCallable pubMedUriParserCallable;
+    // These fixtures parse local files/resources (systemId is null), so the rate limiter is never
+    // exercised; a disabled instance just satisfies the constructor.
+    private final NcbiRateLimiter rateLimiter = new NcbiRateLimiter(2.0, false);
 
     @BeforeClass
     public void setup() throws Exception {
@@ -41,7 +45,7 @@ public class PubmedEFetchHandlerTest {
     public void testJournalTitleParse() throws Exception {
         File initialFile = new File("src/test/resources/reciter/pubmed/callable/31967741.xml");
         inputSource = new InputSource(new FileInputStream(initialFile));
-        pubMedUriParserCallable = new PubMedUriParserCallable(xmlHandler, saxParser, inputSource);
+        pubMedUriParserCallable = new PubMedUriParserCallable(xmlHandler, saxParser, inputSource, rateLimiter);
         List<PubMedArticle> pubMedArticles = pubMedUriParserCallable.call();
         PubMedArticle pubMedArticle = pubMedArticles.get(0);
         String journalTitle = pubMedArticle.getMedlinecitation().getArticle().getJournal().getTitle();
@@ -49,7 +53,7 @@ public class PubmedEFetchHandlerTest {
 
         initialFile = new File("src/test/resources/reciter/pubmed/callable/31746150.xml");
         inputSource = new InputSource(new FileInputStream(initialFile));
-        pubMedUriParserCallable = new PubMedUriParserCallable(xmlHandler, saxParser, inputSource);
+        pubMedUriParserCallable = new PubMedUriParserCallable(xmlHandler, saxParser, inputSource, rateLimiter);
         pubMedArticles = pubMedUriParserCallable.call();
         pubMedArticle = pubMedArticles.get(0);
         journalTitle = pubMedArticle.getMedlinecitation().getArticle().getJournal().getTitle();
@@ -59,7 +63,7 @@ public class PubmedEFetchHandlerTest {
     @Test
     public void testAuthorOrcid() throws Exception {
         inputSource = new InputSource(this.getClass().getResourceAsStream("31482638.xml"));
-        pubMedUriParserCallable = new PubMedUriParserCallable(xmlHandler, saxParser, inputSource);
+        pubMedUriParserCallable = new PubMedUriParserCallable(xmlHandler, saxParser, inputSource, rateLimiter);
         List<PubMedArticle> pubMedArticles = pubMedUriParserCallable.call();
         PubMedArticle pubMedArticle = pubMedArticles.get(0);
         log.debug(pubMedArticle.getMedlinecitation().getArticle().getAuthorlist().get(0).getOrcid());
@@ -78,7 +82,7 @@ public class PubmedEFetchHandlerTest {
     @Test
     public void testEqualContribDeduplication() throws Exception {
         inputSource = new InputSource(this.getClass().getResourceAsStream("equalcontrib.xml"));
-        pubMedUriParserCallable = new PubMedUriParserCallable(xmlHandler, saxParser, inputSource);
+        pubMedUriParserCallable = new PubMedUriParserCallable(xmlHandler, saxParser, inputSource, rateLimiter);
         List<PubMedArticle> pubMedArticles = pubMedUriParserCallable.call();
         PubMedArticle pubMedArticle = pubMedArticles.get(0);
 
@@ -102,7 +106,7 @@ public class PubmedEFetchHandlerTest {
     @Test
     public void testReferenceList() throws Exception {
         inputSource = new InputSource(this.getClass().getResourceAsStream("32025781.xml"));
-        pubMedUriParserCallable = new PubMedUriParserCallable(xmlHandler, saxParser, inputSource);
+        pubMedUriParserCallable = new PubMedUriParserCallable(xmlHandler, saxParser, inputSource, rateLimiter);
         List<PubMedArticle> pubMedArticles = pubMedUriParserCallable.call();
         PubMedArticle pubMedArticle = pubMedArticles.get(0);
         assertEquals(38, pubMedArticle.getMedlinecitation().getCommentscorrectionslist().size(), "The referenceList matches");
@@ -111,7 +115,7 @@ public class PubmedEFetchHandlerTest {
     @Test
     public void testArticleTitleLineBreakRemoval() throws Exception {
         inputSource = new InputSource(this.getClass().getResourceAsStream("32025781.xml"));
-        pubMedUriParserCallable = new PubMedUriParserCallable(xmlHandler, saxParser, inputSource);
+        pubMedUriParserCallable = new PubMedUriParserCallable(xmlHandler, saxParser, inputSource, rateLimiter);
         List<PubMedArticle> pubMedArticles = pubMedUriParserCallable.call();
         PubMedArticle pubMedArticle = pubMedArticles.get(0);
         assertEquals("<b> <i>Propionibacterium acnes</i> </b> Host Inflammatory Response During Periprosthetic Infection Is Joint Specific.", pubMedArticle.getMedlinecitation().getArticle().getArticletitle(), "The ArticleTitle matches");
@@ -120,7 +124,7 @@ public class PubmedEFetchHandlerTest {
     @Test
     public void testHexadecimalLiteralRemoval() throws Exception {
         inputSource = new InputSource(this.getClass().getResourceAsStream("32025781.xml"));
-        pubMedUriParserCallable = new PubMedUriParserCallable(xmlHandler, saxParser, inputSource);
+        pubMedUriParserCallable = new PubMedUriParserCallable(xmlHandler, saxParser, inputSource, rateLimiter);
         List<PubMedArticle> pubMedArticles = pubMedUriParserCallable.call();
         String articleTitle = pubMedArticles.get(0).getMedlinecitation().getArticle().getArticletitle();
         assertEquals("<b> <i>Propionibacterium acnes</i> </b> Host Inflammatory Response During Periprosthetic Infection Is Joint Specific.", articleTitle);


### PR DESCRIPTION
Promotes the post-#148 `dev` work to `master`. **8 commits / 15 files**, all individually merged to `dev` with green CI (including the AWS CodeBuild pipeline build).

### Bundled changes
- **#149** — Drop explicit Jackson pins; Boot 2.7.18 BOM now manages Jackson **2.13.5** (≥ the 2.12.7.1 CVE pin it replaced). Runtime-verified.
- **#151** — Docs: `docs/deploy-and-approval-runbook.md` + `docs/rate-limiter-design-117.md`.
- **#152 (#117)** — Per-pod NCBI rate limiter (`NcbiRateLimiter`) acquired before both ESearch and EFetch; EFetch honors `Retry-After`; shared per-pod pause. Configurable; default 2 req/s/pod. 20/20 tests, throttling verified under concurrency.
- **#153 (#120)** — Springfox 3.0.0 → `springdoc-openapi-ui:1.8.0`; OpenAPI-3 annotations; `ANT_PATH_MATCHER` workaround removed; `swagger-models` pinned to 2.2.20; nginx api-docs route `/pubmed/v2`→`/pubmed/v3`. Swagger UI + `/v3/api-docs` verified.

### ⚠️ Prod-deploy gate (read before merging)
Merging this to `master` **auto-triggers the prod CodePipeline** (`ReCiter-Pubmed-Retrieval-Tool-prod`), which will queue a new execution at the **ManualApproval** gate. The **#148** prod deploy is *still parked* at that gate (unapproved). Merging this will make the eventual prod deploy ship the full `master` tip (everything through #153). The prod deploy itself remains **mrj4001's approval** per policy — this PR/merge does not deploy to prod by itself.

On merge, closes (or finishes the rollout step of): #117, #120 — and brings #113/#119/#122's code to where it can be deployed.