### PR TITLE
Exclude swagger-codegen plugin closure from reciter-pubmed-model (#155)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,22 +19,6 @@
         <java.version>11</java.version>
     </properties>
 
-    <dependencyManagement>
-        <dependencies>
-            <!-- Pin swagger-models to the version springdoc-openapi 1.8.0's swagger-core (2.2.20)
-                 expects. The reciter-pubmed-model dependency transitively drags in the unused
-                 swagger-codegen maven plugin, which forces the ancient swagger-models 2.0.0; that
-                 old version is missing classes springdoc references and breaks startup (#120).
-                 Pinning here (rather than excluding swagger-codegen) avoids disturbing other
-                 libraries the build picks up transitively through that same chain. -->
-            <dependency>
-                <groupId>io.swagger.core.v3</groupId>
-                <artifactId>swagger-models</artifactId>
-                <version>2.2.20</version>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -99,7 +83,38 @@
         			<groupId>com.amazonaws</groupId>
         			<artifactId>aws-java-sdk-dynamodb</artifactId>
         		</exclusion>
+        		<!-- reciter-pubmed-model declares the swagger-codegen *maven plugin* as a regular
+        		     compile dependency, dragging its entire code-generation closure onto the runtime
+        		     classpath: swagger-codegen/parser release candidates, the legacy swagger 1.5.x
+        		     core/models/annotations, handlebars, rhino, json-schema-validator, and a full
+        		     embedded Maven/Aether/Plexus build runtime (~50 jars). None of it is used at
+        		     runtime, and the ancient swagger-models 2.0.0 it forced collided with springdoc
+        		     (#120, whose dependencyManagement pin this replaces). Exclude the whole closure;
+        		     httpclient and commons-io, which the app uses directly, only reached us through this
+        		     chain and are re-declared explicitly below. (Artifacts the app genuinely needs, such
+        		     as springdoc's swagger-core/models/annotations 2.2.20 and jackson-dataformat-yaml,
+        		     arrive via other compile paths and are unaffected.) -->
+        		<exclusion>
+        			<groupId>io.swagger</groupId>
+        			<artifactId>swagger-codegen-maven-plugin</artifactId>
+        		</exclusion>
         	</exclusions>
+        </dependency>
+        <!-- Promoted from transitive to explicit: the retrieval service uses Apache HttpClient
+             (PubMedArticleRetrievalService / HttpClientConfig) and Commons IO (IOUtils) directly,
+             but both previously arrived only through reciter-pubmed-model's now-excluded
+             swagger-codegen closure. httpclient is left versionless so the Spring Boot 2.7 BOM
+             manages it (4.5.14, pulling httpcore + commons-codec); commons-io is not BOM-managed,
+             so it is declared at a current release (the stale transitive 2.4 carried
+             CVE-2024-47554). -->
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.16.1</version>
         </dependency>
         <dependency>
             <groupId>org.jsmart</groupId>


### PR DESCRIPTION
Closes #155. Replaces the #120 workaround with a proper fix.

## What

`reciter-pubmed-model:2.0.3` mistakenly declares the **`swagger-codegen-maven-plugin`** (a Maven *plugin*) as a regular compile dependency, so its entire code-generation closure was bundled into our runtime fat jar. This excludes the closure and re-declares the two libraries the app actually uses.

```
pom.xml | 31 +++++++++++++++++++++++---------- (1 file)
```

1. **Exclude** `io.swagger:swagger-codegen-maven-plugin` from `reciter-pubmed-model` (mirrors the #119/#144 exclusion passes).
2. **Re-declare** the two deps that previously arrived *only* through that closure but are used directly by the app:
   - `org.apache.httpcomponents:httpclient` — versionless, Spring Boot 2.7 BOM manages it to `4.5.14` (with `httpcore` + `commons-codec`). Used by `PubMedArticleRetrievalService` / `HttpClientConfig`.
   - `commons-io:2.16.1` — not BOM-managed; the stale transitive `2.4` carried **CVE-2024-47554**. Used by `PubMedArticleRetrievalService` (`IOUtils.copy`).
3. **Remove** the `swagger-models:2.2.20` `dependencyManagement` pin added in #120 — now redundant because springdoc-openapi's swagger-core supplies `2.2.20` directly once the codegen closure (which forced the ancient `2.0.0`) is gone.

## Why it matters

The closure dragged ~50 artifacts with no runtime purpose onto the classpath, including an **embedded Maven 3.2.5 / Aether / Plexus build runtime**, `rhino` (JS engine), `json-schema-validator`, `handlebars`, `joda-time`, `libphonenumber`, swagger RCs, and `commons-io 2.4`.

| | before (`dev`) | after |
|---|---|---|
| fat jar | 41 MB | **32 MB** |
| bundled jars | 118 | **57** |
| compile/runtime artifacts removed | — | **56** |

## Verification (JDK 11)

- `mvn clean package` ✅ BUILD SUCCESS
- Unit tests (`PubmedEFetchHandlerTest`, `PubMedUriParserCallableTest`, `PubMedArticleRetrievalServiceTest`, `NcbiRateLimiterTest`) ✅ **20/20**
- Dependency tree: no `swagger-codegen`/`parser`/`handlebars`/`rhino`/`maven-*` on compile/runtime; `swagger-models` resolves to `2.2.20` from springdoc without the pin; `httpclient 4.5.14` + `commons-io 2.16.1` retained.
- Runtime boot on :8083 — `/pubmed/ping`=200, `/v3/api-docs`=200 (valid OpenAPI), `/swagger-ui/index.html`=200, `/pubmed/query/Kukafka+R[au]`=200 (**120 articles** via httpclient + IOUtils).
- Adversarial review (4 independent lenses: runtime-classpath risk, dependency correctness, CVE-surface delta, repo consistency) — all **PASS**, no blocking findings.

## Notes / follow-ups

- The upstream root cause is the malformed `reciter-pubmed-model` POM; fixing it in the `ReCiter-PubMed-Model` repo would make this exclusion unnecessary (noted in #155).
- `gson` (also model-transitive, unused at runtime) is left untouched — already at a CVE-safe `2.9.1` via the BOM; out of scope here.