### PR TITLE
Design docs: #130 REST API conventions + #136 Boot 3 migration scoping

### DIFF
--- a/docs/api-conventions-130.md
+++ b/docs/api-conventions-130.md
@@ -1,0 +1,73 @@
+# REST API Conventions — Design & Client-Impact (#130)
+
+**Status:** Design proposal. **No code changes here** — this doc exists so the breaking pieces are coordinated with the consuming ReCiter client before implementation, per the issue.
+**Issue:** #130 · **Related:** #136 (Boot 3 — the trailing-slash routes 404 there, so the two are coupled).
+**Date:** 2026-06-14 · refs are against `dev` (`2a7689d`).
+
+---
+
+## 1. Problems (from the Jun 2026 review)
+
+| # | Problem | Location | Breaking to clients? |
+|---|---------|----------|----------------------|
+| P1 | Trailing-slash routes (`/query-complex/`, `/query-number-pubmed-articles/`) rely on legacy matching removed by default in Spring 6 / Boot 3 → will 404 after the upgrade | controller `@RequestMapping` values | **YES** (see §2) |
+| P2 | Primary search term is a path variable (`/query/{query}`) containing spaces and `[]` — proxies/Tomcat may reject; belongs in a query param or body | `GET /query/{query}` | **No** — unused by ReCiter (§2) |
+| P3 | Inconsistent return types (`int`, `List<…>`, `ResponseEntity<List<…>>`); no URL versioning | all 3 query endpoints | Partly |
+| P4 | `fields` Squiggly filter is force-lowercased and unvalidated → typos silently yield empty objects | controller `~95–115` | **No** — unused by ReCiter (§2) |
+
+---
+
+## 2. Client-impact analysis (evidence-based)
+
+The only in-workspace consumer is the main **ReCiter** app. It calls exactly three endpoints, all via `PUBMED_SERVICE` (env var) + `RestTemplate`:
+
+| Endpoint (as called) | ReCiter call site | Shape |
+|----------------------|-------------------|-------|
+| `POST /pubmed/query-complex/` | `pubmed/retriever/PubMedArticleRetriever.java:46,51` | body `PubMedQuery` → `PubMedArticle[]` |
+| `POST /pubmed/query-number-pubmed-articles/` | `xml/retriever/pubmed/AbstractRetrievalStrategy.java:270` | body `PubMedQuery` → `int` |
+| `GET /pubmed/ping` | `Application.java:218` | health probe |
+
+ReCiter prepends `/pubmed` only when `PUBMED_SERVICE` doesn't already end in `/pubmed`, and **hardcodes the trailing slash** on both POSTs.
+
+**Decisive consequences:**
+- ReCiter does **not** use `GET /query/{query}` or the `fields` param. So **P2 and P4 are internal-only** — they can be fixed unilaterally with zero client coordination. (`/query/{query}` has no in-workspace consumer at all; confirm no external/manual users before removing it, but it is safe to *augment*.)
+- The **breaking surface is precisely the two trailing-slash POST paths** ReCiter hardcodes. Any rename, de-slashing, or version-prefixing of those **breaks ReCiter unless coordinated**.
+- That same trailing slash is what **404s under Boot 3** (Spring 6 sets `setUseTrailingSlashMatch(false)` permanently). So #130's P1 and the #136 migration must land together or ReCiter retrieval breaks in prod.
+
+---
+
+## 3. Proposed canonical API
+
+Target a clean, versioned surface while keeping a **compatibility window**:
+
+| Concern | Proposal |
+|---------|----------|
+| Versioning | Introduce a `/v1` segment: `/pubmed/v1/articles`, `/pubmed/v1/article-count`. Frees future breaking changes to go to `/v2`. |
+| Trailing slashes | Canonical paths have **no** trailing slash. During transition, explicitly map both slash and no-slash (an explicit dual `@RequestMapping(path = {"/x", "/x/"})` works even on Boot 3, since the 404 is only from *implicit* matching). |
+| Search term placement (P2) | Keep term in the **body** (already true for the two POSTs ReCiter uses). For the GET, add `GET /pubmed/v1/articles?term=...` (query param, URL-encoded) and deprecate the `{query}` path variable. |
+| Return types (P3) | Standardize on `ResponseEntity<T>` with explicit status codes. Count returns `{"count": N}` JSON, not a bare `int`. |
+| `fields` validation (P4) | Validate the Squiggly expression against the `PubMedArticle` schema; return `400` with the offending token instead of silently emptying objects. Drop the blanket `toLowerCase()` (it already relies on `ACCEPT_CASE_INSENSITIVE_PROPERTIES`). |
+
+---
+
+## 4. Migration strategy (coordinated, phased)
+
+Because the breaking surface is small (two POST paths) and the client is in the same org, a **dual-route transition** is cheap and zero-downtime:
+
+1. **Tool, additive (non-breaking):** add the new canonical routes *and* keep the existing trailing-slash routes by mapping both path forms explicitly. Fix P2/P4 (internal) in the same release. Ship to dev → prod. Nothing breaks.
+2. **Client (ReCiter):** switch `PubMedArticleRetriever`/`AbstractRetrievalStrategy` to the new no-slash (`/v1`) paths. Deploy.
+3. **Tool, removal (breaking, later):** once ReCiter is confirmed on the new paths in prod, drop the legacy trailing-slash routes. This is the only step that requires the explicit slash-matching shim to be removed — and by then nothing calls it.
+
+This sequencing means **P1 is resolved before the Boot 3 cutover** (#136): after step 1, the tool no longer depends on implicit trailing-slash matching, so the Boot 3 upgrade can't 404 the ReCiter integration.
+
+---
+
+## 5. Recommended decisions / open questions for the ReCiter-client owners
+
+- **OK to add a `/v1` segment?** (Cleanest, but ReCiter must update `PUBMED_SERVICE` path handling.) If not, a slash-tolerant shim on the existing paths is the minimum viable fix for the Boot 3 blocker.
+- **Is `GET /query/{query}` used by anything outside this workspace** (manual ops, dashboards, other services)? If truly unused, P2 collapses to "delete it." If used, add the query-param form and deprecate.
+- **Count response shape:** bare `int` → `{"count": N}` is cleaner but is itself a breaking change for ReCiter's `int` deserialization. Either keep `int` for `/v1` or coordinate the DTO change.
+
+## 6. Sequencing recommendation
+
+Do **step 1 (additive)** as a small near-term PR — it is non-breaking, fixes the internal P2/P4 cleanly, and **unblocks the Boot 3 migration** by removing the implicit-trailing-slash dependency. Defer steps 2–3 to be coordinated with the ReCiter deploy cadence. Treat P1 (slash-tolerance) as a **hard prerequisite checklist item inside #136**, not an independent effort.

--- a/docs/boot3-java17-migration-136-scoping.md
+++ b/docs/boot3-java17-migration-136-scoping.md
@@ -1,0 +1,77 @@
+# Boot 3 / Java 17 / jakarta Migration — Scoping & Sequencing (#136)
+
+**Status:** Scoping plan for a **deferred** epic. This is sequencing, not a green light. Per #136, the trigger to *start* is an org mandate or a CVE only a 3.x patch fixes — **not a calendar date**.
+**Issue:** #136 · **Related:** #130 (trailing-slash routes 404 under Boot 3 — a hard prerequisite), #113/#146 (2.7 bump), #120/#153 (springdoc), #122/#142 (tests).
+**Date:** 2026-06-14 · refs against `dev` (`2a7689d`).
+
+---
+
+## 1. What changed since the issue was filed — both gates are now cleared
+
+The issue named two prerequisites for even considering this. Both are now done on `dev` (awaiting dev→master promotion):
+
+| Gate (per #136) | Status |
+|-----------------|--------|
+| **Springfox removal** (the "hard blocker" — Springfox is incompatible with Boot 3) | ✅ Done — #120/#153 replaced Springfox with springdoc-openapi 1.8.0 |
+| **Real unit-test safety net in CI** (#122 — parser edge cases, query-drop, threshold) | ✅ Done — #142/#122; 20 tests run in CodeBuild |
+| Bounded 2.5→2.7 stepping stone (#113) | ✅ Done — #146 (Boot 2.7.18, still javax) |
+
+**Implication:** the migration is materially de-risked versus when it was deferred. The remaining work is a Boot 2.7→3.x dependency/version coordination, not a code rewrite (see §2).
+
+---
+
+## 2. Migration surface assessment — small, and dependency-driven
+
+This is a ~2,650-LOC internal service. The actual code-level jakarta surface is **near-zero**:
+
+- The only `javax.*` imports are `javax.xml.parsers.*` / `javax.xml.*` (4 files). **These are JAXP/SAX from the JDK (`java.xml` module) — NOT part of the `javax → jakarta` rename.** They stay unchanged on Java 17 / Boot 3.
+- **No** `javax.servlet`, `javax.persistence`, `javax.validation`, `javax.annotation` usage in `src/main` on `dev`. So there is no namespace rewrite of application code.
+- Controllers use Spring abstractions (`ResponseEntity`, `@RequestMapping`) only — these survive Boot 3 with minor semantics changes (trailing slash, see §4).
+
+So the migration is **driven by dependencies and the runtime**, not source rewrites:
+
+| Component | From (dev) | To (Boot 3) | Risk |
+|-----------|------------|-------------|------|
+| Spring Boot | 2.7.18 | 3.3.x / 3.4.x (only OSS-security-supported line) | medium — transitive churn |
+| Java | 11 | 17 (Corretto) | low — see `MigrationFromJDk11ToAWSCorretto17` (but see §3) |
+| Embedded Tomcat | 9.x | 10.x (jakarta) | low — transitive via Boot |
+| springdoc-openapi | 1.8.0 | 2.x (requires Boot 3 / jakarta) | low — same project, config 1:1 |
+| squiggly-filter-jackson | 1.3.18 | **unverified on Boot 3 / Jackson 2.15+** | **HIGH — the real wildcard (§3)** |
+| Lombok | 1.18.34 | ok for 17 | low |
+| reciter-pubmed-model | 2.0.3 | unchanged (no javax.servlet; jackson/dynamodb/lombok only) | low |
+| zerocode-tdd / testng / mockito | test scope | verify Boot 3 / Java 17 compat | low–medium |
+
+---
+
+## 3. Risk register
+
+1. **`squiggly-filter-jackson:1.3.18` (highest risk).** Unmaintained; pins to older Jackson internals. Boot 3 ships Jackson 2.15+. If Squiggly breaks, the `fields` feature needs a replacement (e.g. Jackson `@JsonFilter`/`FilterProvider`, or `josdejong/squiggly` fork). **Phase 0 must dependency-dry-run this before committing.**
+2. **The existing `MigrationFromJDk11ToAWSCorretto17` branch is a trap — do not use it as a base.** It has diverged badly from current `dev`: it *deletes* the very tests #122 added (`PubMedArticleRetrievalServiceTest` −191, `PubmedEFetchHandlerTest` −30), removes `GlobalExceptionHandler`/`HttpClientConfig`/`logback-spring.xml`, and adds header-dump debug cruft ("dumping all the headers… for debugging the protocal", "commented this code"). Start the migration **fresh from `dev`**; harvest at most isolated ideas (e.g. `ProxyConfig`) by cherry-pick, not the branch.
+3. **Trailing-slash 404 (#130 P1).** Spring 6 removes implicit trailing-slash matching; ReCiter calls `POST …/query-complex/` and `…/query-number-pubmed-articles/` with hardcoded trailing slashes. **This breaks the ReCiter integration on cutover unless #130 step 1 (slash-tolerant routes) lands first.** Hard prerequisite, not optional.
+4. **Deploy pipeline / image.** CodeBuild now builds corretto11 (#147). Java 17 needs the buildspec/image bumped to corretto17 and the Dockerfile base image updated — coordinate with the (recently repaired) prod pipeline.
+
+---
+
+## 4. Phased plan (when triggered)
+
+**Phase 0 — De-risk (no production change):**
+- Dependency dry-run on a throwaway branch: bump Boot → 3.3.x, Java → 17, springdoc → 2.x; resolve the tree; **specifically prove `squiggly-filter-jackson` works or pick a replacement.** Output: a go/no-go with the exact replacement plan for any incompatible dep.
+- Confirm the test suite (#122) is green as the regression net **before** touching anything.
+
+**Phase 1 — API slash-tolerance (#130 step 1):** land the additive, slash-tolerant routes so the Boot 3 cutover can't 404 ReCiter. Ships independently, non-breaking.
+
+**Phase 2 — Boot 3 + jakarta + Tomcat 10:** bump Boot to 3.x, springdoc to 2.x; apply any jakarta touch-ups (expected minimal per §2); fix `application.properties` keys renamed in Boot 3; run the full suite + runtime boot (ping, real query, count, swagger, rate limiter).
+
+**Phase 3 — Java 17 / Corretto:** set `java.version=17`, bump CodeBuild + Dockerfile to corretto17, remove any `--source 11` constraints. Re-run suite + runtime.
+
+**Phase 4 — Cleanup:** drop legacy trailing-slash routes once ReCiter is on the new paths (#130 step 3); delete the stale `MigrationFromJDk11ToAWSCorretto17` branch.
+
+Each phase is independently buildable/verifiable on JDK 17, gated by the #122 suite + a runtime boot smoke (the same battery used in `plans/DEV-PROMOTION-READINESS.md`).
+
+---
+
+## 5. Trigger & decision
+
+Unchanged from #136: **do not start without an org mandate or a Boot-3-only CVE.** Java 11 is supported into ~2027; Boot 2.7 is past free OSS EOL, which is the main standing pressure. When the trigger arrives, Phase 0's squiggly dry-run is the single most important gate — schedule it first.
+
+**Bottom line:** the blockers the issue cited are gone; the migration is now mostly a dependency-coordination project with one genuine wildcard (Squiggly) and one hard cross-service prerequisite (#130 trailing slashes). Estimated as a small number of sequential PRs, not an open-ended rewrite.


### PR DESCRIPTION
Two **design/planning docs only** — no behavior change — for the deferred forward-work items. Mirrors the #151 pattern of landing design docs in `docs/`.

## `docs/api-conventions-130.md` (#130)
Design + **client-impact analysis** for the REST convention fixes. Key finding from auditing the consumer:

- The only in-workspace consumer (the main **ReCiter** app) calls exactly three endpoints, all with **hardcoded trailing slashes**: `POST /pubmed/query-complex/` (`PubMedArticleRetriever.java:46`), `POST /pubmed/query-number-pubmed-articles/` (`AbstractRetrievalStrategy.java:270`, deserialized as `Integer.class`), and `GET /pubmed/ping`.
- It does **not** use `GET /query/{query}` or the `fields` param → **P2 (path-encoded term) and P4 (fields validation) are internal-only** and fixable unilaterally.
- The breaking surface is **just the two trailing-slash POSTs** — which also **404 under Boot 3**, coupling this to #136.

Proposes a **dual-route transition** (add canonical/slash-tolerant routes → migrate ReCiter → drop legacy) that resolves P1 *before* the Boot 3 cutover.

## `docs/boot3-java17-migration-136-scoping.md` (#136)
Phased scoping plan for the deferred epic, with an important update: **both gates the issue named are now satisfied on dev** — Springfox removal (#120/#153, the "hard blocker") and the test safety net (#122/#142). Plus:

- Code-level jakarta surface is **near-zero** (only JDK `javax.xml` — verified; no `javax.servlet/persistence/validation/annotation`). The migration is dependency-driven, not a source rewrite.
- The **real wildcard is `squiggly-filter-jackson:1.3.18`** (unmaintained, Boot-3/Jackson-2.15 compat unverified) — Phase 0 dry-run gate.
- The existing `MigrationFromJDk11ToAWSCorretto17` branch is **stale/unusable as a base** (it deletes the #122 tests and adds debug cruft) — start fresh from dev.
- 4-phase sequence, each independently buildable/verifiable on JDK 17, gated by the #122 suite.

## Notes
- Trigger to *start* #136 is unchanged (org mandate / Boot-3-only CVE), per the issue.
- Both issues remain open; these docs inform but don't implement. Review-only.