### PR TITLE
Upgrade to Java 17 (Corretto) on Spring Boot 2.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: '11'
+          java-version: '17'
           cache: maven
 
       # Build and run unit tests, but exclude the live load tests

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:11-jre-alpine
+FROM eclipse-temurin:17-jre-alpine
 
 # wget is used by the HEALTHCHECK below
 RUN apk add --no-cache wget

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -3,7 +3,7 @@ version: 0.2
 phases:
   install:
     runtime-versions:
-      java: corretto11
+      java: corretto17
     commands:
       - echo Nothing to do in the install phase...
   pre_build:

--- a/k8-buildspec.yml
+++ b/k8-buildspec.yml
@@ -3,7 +3,7 @@ version: 0.2
 phases:
   install:
     runtime-versions:
-      java: corretto11
+      java: corretto17
     commands:
       # Modern CodeBuild images do not bundle kubectl; install a pinned client.
       - curl -sSLo /usr/local/bin/kubectl https://dl.k8s.io/release/v1.29.10/bin/linux/amd64/kubectl

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <java.version>11</java.version>
+        <java.version>17</java.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
Standalone **Java 11 → 17** upgrade, **decoupled from the Boot 3 / jakarta epic (#136)**. Spring Boot 2.7 fully supports Java 17, so this needs *no* jakarta namespace migration, no Springfox removal, none of the epic's churn — just the JDK bump and a matching runtime image.

## Changes (4 files, +4/−4)
| File | From | To | Why |
|------|------|----|----|
| `pom.xml` | `java.version` 11 | 17 | compile to bytecode 17 |
| `Dockerfile` | `eclipse-temurin:11-jre-alpine` | `17-jre-alpine` | **required** — bytecode 17 can't run on an 11 JRE |
| `buildspec.yml` | `java: corretto11` | `corretto17` | CodeBuild compile env |
| `k8-buildspec.yml` | `java: corretto11` | `corretto17` | CodeBuild image-build env |

> The Dockerfile + buildspec bumps are not optional cosmetics: a `java.version=17` jar throws `UnsupportedClassVersionError` on a Java 11 runtime, so the build image and base image must move together. That's the whole change.

## Verification (Temurin 17 locally)
| Level | Result |
|-------|--------|
| `mvn clean package` (java.version=17) | ✅ BUILD SUCCESS — **Lombok 1.18.34 processes fine on 17** (the old "needs JDK 11" constraint was a pre-1.18.30 Lombok issue) |
| Unit suite | ✅ **20/20** on JDK 17 |
| Bare-jar boot + smoke | ✅ "using Java 17.0.18"; `/pubmed/ping`, `/pubmed/query` (120 articles), `/v3/api-docs`, `/swagger-ui` all 200 |
| **Docker image (amd64 deploy platform)** | ✅ builds from `eclipse-temurin:17-jre-alpine`; both 11 and 17 alpine tags are amd64-only (identical platform support) |
| **amd64 container run** | ✅ starts as non-root PID 1 on **Java 17.0.19**, serves `/pubmed/ping` → 200 `Healthy` |

## Notes
- Relates to **#136** (this is its "Java 11 → 17 (Corretto)" line item, done standalone) and **supersedes the stale `MigrationFromJDk11ToAWSCorretto17` branch** without that branch's divergence (it had deleted the #122 tests + added debug cruft).
- Java 11 isn't EOL until ~2027, so this isn't urgent — but it's low-risk and clears the way. Per the prod-approval policy, this goes to **dev only**; the dev→master promotion (prod deploy) remains mrj4001's call.
- The Boot 3 / jakarta migration (#136 proper) is still deferred and gated on its trigger; this does not touch it.