### PR TITLE
Fix default build (exclude live load tests) + run full unit suite in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,15 +11,16 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
 
-      - name: Set up Temurin JDK 11
+      - name: Set up Temurin JDK 17
         uses: actions/setup-java@v4
         with:
           distribution: temurin
           java-version: '17'
           cache: maven
 
-      # Build and run unit tests, but exclude the live load tests
-      # (ReCiterPubmedApiLoadTest / LoadTest) which require a running
-      # service on localhost:5000 and would otherwise fail the build.
+      # Build and run the full unit suite. The live load tests
+      # (reciter.pubmed.loadtest.*) are excluded via the maven-surefire-plugin
+      # config in pom.xml, so this picks up every unit test automatically with
+      # no hardcoded -Dtest list to keep in sync.
       - name: Build and test
-        run: mvn -B -ntp clean package -Dtest=PubmedEFetchHandlerTest,PubMedUriParserCallableTest,PubMedArticleRetrievalServiceTest -DfailIfNoTests=false
+        run: mvn -B -ntp clean package

--- a/pom.xml
+++ b/pom.xml
@@ -124,6 +124,21 @@
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
             </plugin>
+            <!-- Exclude the live load tests (reciter.pubmed.loadtest.*) from the default test
+                 phase: they make live HTTP calls to a deployed/authenticated service and return
+                 403 without one, which would otherwise fail `mvn clean package` for everyone. They
+                 stay runnable on demand via an explicit -Dtest=ReCiterPubmedApiLoadTest. The real
+                 unit tests (parser, retrieval, rate limiter) now run by default and in CI without a
+                 hardcoded test list. -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <excludes>
+                        <exclude>**/loadtest/**</exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
Two small build/CI fixes surfaced while testing the Java 17 merge (#158).

## 1. `mvn clean package` failed for everyone
There was no surefire config, so the default test phase ran the **live load tests** (`reciter.pubmed.loadtest.LoadTest` + `ReCiterPubmedApiLoadTest`), which make live HTTP calls to a deployed/authenticated service and return **403** locally. A plain `mvn clean package` therefore failed unless you used `-DskipTests` or a named `-Dtest=` list.

**Fix:** add a `maven-surefire-plugin` `<excludes>` for `**/loadtest/**`. The default test phase now runs only the real unit tests; the load tests remain runnable on demand via `-Dtest=ReCiterPubmedApiLoadTest`.

## 2. CI silently skipped the rate-limiter tests
`ci.yml` hardcoded three classes:
```
-Dtest=PubmedEFetchHandlerTest,PubMedUriParserCallableTest,PubMedArticleRetrievalServiceTest
```
That **omitted `NcbiRateLimiterTest`** (the #117 rate limiter) — so it never ran in CI — and silently excludes any future test class.

**Fix:** with the load tests excluded in the pom, CI just runs `mvn clean package`, which now exercises the **full unit suite automatically** (no list to keep in sync). Also corrected the stale "Set up Temurin JDK 11" step name (it already installs 17, post-#158).

## Verification (JDK 17, on current dev)
- `mvn clean package` → ✅ BUILD SUCCESS, **20/20** unit tests, **zero** load-test/403 output (was 21 tests / 1 failure before).
- The 20 now include `NcbiRateLimiterTest`, which CI was missing.
- CI on this PR runs the new `mvn clean package`, so a green check here *is* the end-to-end proof that the full suite (incl. the rate limiter) passes.

Docs/`build-toolchain` note about "don't let the load test gate a build" is now resolved at the source. Goes to `dev` only.