### PR TITLE
feat(pubmed): sort and retmax on /query-complex/, so a caller can ask for a ranked slice

### DIFF
--- a/src/main/java/reciter/controller/PubMedRetrievalToolController.java
+++ b/src/main/java/reciter/controller/PubMedRetrievalToolController.java
@@ -54,10 +54,17 @@ public class PubMedRetrievalToolController {
         return retrieve(query, fields);
     }
 
+    /**
+     * Optionally accepts {@code sort} ({@code relevance} or {@code date}) and {@code retmax} in the
+     * request body, so a caller can ask for a ranked slice — "the top 50 by relevance" — instead of
+     * the first N matches in PubMed's default order. Both are optional: a body that omits them
+     * produces exactly the request this endpoint made before sort support existed.
+     */
     @RequestMapping(value = "/query-complex/", method = RequestMethod.POST)
     @ResponseBody
     public ResponseEntity<List<PubMedArticle>> queryComplex(@RequestBody PubMedQuery pubMedQuery) throws IOException {
-        List<PubMedArticle> pubMedArticles = query(pubMedQuery.toString(), null);
+        List<PubMedArticle> pubMedArticles =
+                retrieve(pubMedQuery.toString(), null, pubMedQuery.getSort(), pubMedQuery.getRetmax());
         return ResponseEntity.ok(pubMedArticles);
     }
 
@@ -80,10 +87,19 @@ public class PubMedRetrievalToolController {
     }
 
     private List<PubMedArticle> retrieve(String query, String fields) throws IOException {
-        query = URLEncoder.encode(query, "UTF-8");
-        log.info("Retrieving with query=[{}]", query);
+        return retrieve(query, fields, null, null);
+    }
 
-        List<PubMedArticle> pubMedArticles = pubMedArticleRetrievalService.retrieve(query);
+    private List<PubMedArticle> retrieve(String query, String fields, String sort, Integer retmax) throws IOException {
+        query = URLEncoder.encode(query, "UTF-8");
+        log.info("Retrieving with query=[{}], sort=[{}], retmax=[{}]", query, sort, retmax);
+
+        // When no sort/retmax is requested, dispatch through the original single-argument service
+        // method so the unsorted path — the one the ReCiter engine uses — is provably unchanged.
+        List<PubMedArticle> pubMedArticles =
+                (sort == null || sort.isEmpty()) && retmax == null
+                        ? pubMedArticleRetrievalService.retrieve(query)
+                        : pubMedArticleRetrievalService.retrieve(query, sort, retmax);
         log.info("Retrieved [{}] PubMed articles using query=[{}]", pubMedArticles.size(), query);
 
         // No field selection requested: return the retrieved articles directly and skip the

--- a/src/main/java/reciter/pubmed/model/PubMedQuery.java
+++ b/src/main/java/reciter/pubmed/model/PubMedQuery.java
@@ -57,6 +57,29 @@ public class PubMedQuery {
     @JsonProperty("doi")
     private String doi;
 
+    /**
+     * Optional ESearch sort order. Accepts {@code relevance} and {@code date} (an alias for NCBI's
+     * {@code pub_date}, which is what actually goes on the wire); any other value is ignored and the
+     * query runs in PubMed's default order. When absent, the emitted ESearch request is unchanged
+     * from the pre-sort behavior.
+     * <p>
+     * Deliberately excluded from {@link #toString()}: it is an ESearch request parameter, not part
+     * of the Entrez query term.
+     */
+    @JsonProperty("sort")
+    private String sort;
+
+    /**
+     * Optional cap on how many records EFetch pulls back, letting a caller ask for the top N of a
+     * sorted result set instead of every match. When absent, EFetch uses
+     * {@link reciter.pubmed.querybuilder.PubmedXmlQuery#DEFAULT_RETMAX} exactly as before. Values
+     * above the default are ignored (this is a cap, never an increase).
+     * <p>
+     * Deliberately excluded from {@link #toString()}: see {@link #sort}.
+     */
+    @JsonProperty("retmax")
+    private Integer retmax;
+
     @Override
     public String toString() {
         List<String> parts = new ArrayList<>();

--- a/src/main/java/reciter/pubmed/querybuilder/PubmedXmlQuery.java
+++ b/src/main/java/reciter/pubmed/querybuilder/PubmedXmlQuery.java
@@ -77,6 +77,19 @@ public class PubmedXmlQuery {
      */
     private String retMode = "json";
 
+    /**
+     * Optional ESearch sort order, as a literal wire value: for {@code db=pubmed} this tool sends
+     * only {@code relevance} or {@code pub_date}. Caller input is mapped to one of those (or to
+     * {@code null}) by {@code PubMedArticleRetrievalService.normalizeSort} before it reaches here.
+     * <p>
+     * {@code null} (the default) means "send no sort parameter", which is what PubMed's default
+     * ordering relies on — so an absent sort leaves the emitted ESearch request byte-identical to
+     * the pre-sort behavior. Because the tool searches with {@code usehistory=y}, the sort applied
+     * here determines the order of the result set posted to the history server, and therefore the
+     * order in which EFetch pulls records back off that {@code WebEnv}.
+     */
+    private String sort;
+
     public PubmedXmlQuery() {
     }
 
@@ -115,7 +128,13 @@ public class PubmedXmlQuery {
         sb.append(useHistory);
         sb.append("&retmode=");
         sb.append(retMode);
-        
+        // Appended only when a sort was explicitly requested, so the default-order URL is
+        // byte-identical to what this builder emitted before sort support existed.
+        if (sort != null && !sort.isEmpty()) {
+            sb.append("&sort=");
+            sb.append(sort);
+        }
+
         return sb.toString();
     }
 

--- a/src/main/java/reciter/pubmed/retriever/PubMedArticleRetrievalService.java
+++ b/src/main/java/reciter/pubmed/retriever/PubMedArticleRetrievalService.java
@@ -121,12 +121,28 @@ public class PubMedArticleRetrievalService {
     /**
      * Retrieves all PubMed articles matching {@code pubMedQuery}.
      * <p>
-     * An ESearch determines the matching article count. Because the allowed count is capped at
-     * {@link #RETRIEVAL_THRESHOLD} (2,000), which is well below {@link PubmedXmlQuery#DEFAULT_RETMAX}
-     * (10,000), every allowed query is satisfied by a single EFetch request — there is no need to
-     * paginate over retstart or fan the fetches out across a thread pool. Queries matching more than
-     * the threshold are hard-refused with an {@link IOException}; the message text is matched by
-     * {@code GlobalExceptionHandler} to map the refusal to a 502 response, so it must not change.
+     * An ESearch determines the matching article count. Every retrieval is satisfied by a single
+     * EFetch request — there is no need to paginate over retstart or fan the fetches out across a
+     * thread pool — because the number of records fetched is capped at {@link #RETRIEVAL_THRESHOLD}
+     * (2,000), well below {@link PubmedXmlQuery#DEFAULT_RETMAX} (10,000), by one of two routes:
+     * <ul>
+     *   <li>no {@code retmax}: matched == fetched, so a query matching more than the threshold is
+     *       hard-refused with an {@link IOException}. This is the legacy path the ReCiter engine
+     *       takes, and it is unchanged.</li>
+     *   <li>an explicit {@code retmax} (&le; the threshold): the fetch is bounded by {@code retmax}
+     *       regardless of how many articles matched, so the matched-count refusal does not apply —
+     *       "the 50 most relevant of 24,852" is a narrow fetch over a broad search.</li>
+     * </ul>
+     * The refusal message text is matched by {@code GlobalExceptionHandler}'s
+     * {@code THRESHOLD_EXCEEDED_MARKER}, so it must not change.
+     * <p>
+     * That mapping does NOT currently reach the caller, and the bug predates this change: because
+     * the refusal is an {@link IOException} thrown from inside a {@code @Retryable} method, Spring
+     * Retry exhausts all 7 attempts on it (a permanent condition — the count will not shrink) and
+     * then wraps it, so {@code @ExceptionHandler(IOException.class)} never sees it and the catch-all
+     * returns <strong>500, not 502</strong>. Verified against an unmodified {@code dev} build.
+     * Reported separately; deliberately NOT fixed here, because changing the retry/error semantics
+     * of the engine's own retrieval path does not belong in a change about sort and retmax.
      */
     @Retryable(maxAttempts = 7, value = IOException.class,
         backoff = @Backoff(random = true, delay = 1500, maxDelay = 9000), listeners = {"retryListener"})
@@ -174,11 +190,22 @@ public class PubMedArticleRetrievalService {
                 : getNumberOfPubMedArticles(pubMedQuery, normalizedSort);
         int numberOfPubmedArticles = eSearchResult.getCount();
 
-        // NOTE: the threshold gate applies to the *matched* count, not to retmax. A query matching
-        // more than RETRIEVAL_THRESHOLD articles is still hard-refused even when the caller only
-        // wants the top 50 of them, so a broad relevance search must be narrowed to <= 2000 matches
-        // before it will return anything.
-        if (numberOfPubmedArticles > RETRIEVAL_THRESHOLD) {
+        // The threshold gate exists to bound the EFETCH, which is the expensive half: without a
+        // retmax, an allowed query drags back every matched record in one batch. So the gate keys on
+        // the MATCHED count because, historically, matched == fetched.
+        //
+        // An explicit retmax breaks that identity. The caller is then asking for the top N of the
+        // ordered set, and only N records are ever fetched — the cost the gate protects against no
+        // longer depends on how many articles matched. Applying it anyway would hard-refuse "the 50
+        // most relevant of 24,852", which is not a broad fetch; it is a narrow fetch over a broad
+        // search, and it is exactly what relevance ranking is for.
+        //
+        // So: an explicit retmax bounds the fetch and takes over from the matched-count gate. The
+        // bound itself still holds — retmax may not exceed the threshold — so no caller can use this
+        // to pull back more than RETRIEVAL_THRESHOLD records. Callers that send no retmax (the
+        // ReCiter engine, every legacy path) keep the original matched-count refusal untouched.
+        boolean fetchIsBounded = retmax != null && retmax > 0 && retmax <= RETRIEVAL_THRESHOLD;
+        if (!fetchIsBounded && numberOfPubmedArticles > RETRIEVAL_THRESHOLD) {
             throw new IOException("Number of PubMed Articles retrieved " + numberOfPubmedArticles + " exceeded the threshold level " + RETRIEVAL_THRESHOLD);
         }
 

--- a/src/main/java/reciter/pubmed/retriever/PubMedArticleRetrievalService.java
+++ b/src/main/java/reciter/pubmed/retriever/PubMedArticleRetrievalService.java
@@ -5,6 +5,7 @@ import java.io.InputStream;
 import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 
 import javax.xml.XMLConstants;
 import javax.xml.parsers.ParserConfigurationException;
@@ -53,6 +54,24 @@ public class PubMedArticleRetrievalService {
      * query fits in a single EFetch batch, so no pagination is required.
      */
     private static final int RETRIEVAL_THRESHOLD = 2000;
+
+    /**
+     * ESearch {@code sort} values honored for {@code db=pubmed}. Anything else (an unknown value, a
+     * blank string) is normalized to {@code null}, which means "send no sort parameter at all" —
+     * i.e. it falls back to the exact pre-sort request.
+     * <p>
+     * Note the caller-facing {@code date} is NOT what goes on the wire. NCBI's ESearch sort key for
+     * publication date is {@code pub_date}; a literal {@code sort=date} is silently ignored by
+     * ESearch, which then returns its default order — verified against NCBI, where {@code sort=date}
+     * returns an idlist byte-identical to sending no sort at all (and identical to sending a
+     * garbage sort value), while {@code sort=pub_date} genuinely reorders. Accepting {@code date}
+     * and forwarding it verbatim would therefore reproduce the exact failure this parameter exists
+     * to fix: a caller asks for a ranked result and silently gets default order. So {@code date} is
+     * accepted from callers and mapped to {@code pub_date} here.
+     */
+    private static final String SORT_RELEVANCE = "relevance";
+    private static final String SORT_DATE = "date";
+    private static final String SORT_PUB_DATE = "pub_date";
 
     private static ObjectMapper objectMapper = new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 
@@ -112,10 +131,53 @@ public class PubMedArticleRetrievalService {
     @Retryable(maxAttempts = 7, value = IOException.class,
         backoff = @Backoff(random = true, delay = 1500, maxDelay = 9000), listeners = {"retryListener"})
     public List<PubMedArticle> retrieve(String pubMedQuery) throws IOException {
+        return doRetrieve(pubMedQuery, null, null);
+    }
 
-        PubmedESearchResult eSearchResult = getNumberOfPubMedArticles(pubMedQuery);
+    /**
+     * Sort-aware variant of {@link #retrieve(String)}, used by the {@code query-complex} endpoint
+     * when a caller asks for a ranked slice ("the top N by relevance") rather than every match.
+     *
+     * @param pubMedQuery URL-encoded Entrez query term
+     * @param sort        ESearch sort order; only {@code relevance} and {@code date} are honored.
+     *                    {@code null}, blank, or an unrecognized value means no sort parameter is
+     *                    sent and the request is identical to {@link #retrieve(String)}.
+     * @param retmax      caps how many records EFetch pulls back off the sorted result set;
+     *                    {@code null} (or a value outside 1..{@link PubmedXmlQuery#DEFAULT_RETMAX})
+     *                    leaves the default retmax in place. This is a cap, never an increase.
+     */
+    @Retryable(maxAttempts = 7, value = IOException.class,
+        backoff = @Backoff(random = true, delay = 1500, maxDelay = 9000), listeners = {"retryListener"})
+    public List<PubMedArticle> retrieve(String pubMedQuery, String sort, Integer retmax) throws IOException {
+        return doRetrieve(pubMedQuery, sort, retmax);
+    }
+
+    /**
+     * Shared retrieval body behind both {@code retrieve} overloads.
+     * <p>
+     * Sort is applied to the <em>ESearch</em>, not the EFetch: because the search runs with
+     * {@code usehistory=y}, the ESearch is what posts the (now ordered) result set to the history
+     * server, and the EFetch then walks that {@code WebEnv} from {@code retstart=0}. So sorting at
+     * search time plus a {@code retmax} cap at fetch time is what actually yields "the top N by
+     * relevance" instead of "the first N in PubMed's default order".
+     * <p>
+     * When {@code sort} normalizes to {@code null} this method calls exactly the same one-argument
+     * {@link #getNumberOfPubMedArticles(String)} and leaves retmax at its default, so the emitted
+     * ESearch request is byte-identical to the pre-sort behavior the ReCiter engine depends on.
+     */
+    private List<PubMedArticle> doRetrieve(String pubMedQuery, String sort, Integer retmax) throws IOException {
+
+        String normalizedSort = normalizeSort(sort);
+
+        PubmedESearchResult eSearchResult = (normalizedSort == null)
+                ? getNumberOfPubMedArticles(pubMedQuery)
+                : getNumberOfPubMedArticles(pubMedQuery, normalizedSort);
         int numberOfPubmedArticles = eSearchResult.getCount();
 
+        // NOTE: the threshold gate applies to the *matched* count, not to retmax. A query matching
+        // more than RETRIEVAL_THRESHOLD articles is still hard-refused even when the caller only
+        // wants the top 50 of them, so a broad relevance search must be narrowed to <= 2000 matches
+        // before it will return anything.
         if (numberOfPubmedArticles > RETRIEVAL_THRESHOLD) {
             throw new IOException("Number of PubMed Articles retrieved " + numberOfPubmedArticles + " exceeded the threshold level " + RETRIEVAL_THRESHOLD);
         }
@@ -134,10 +196,14 @@ public class PubMedArticleRetrievalService {
         if (eSearchResult.getWebenv() != null) {
             pubmedXmlQuery.setWebEnv(eSearchResult.getWebenv());
         }
+        // Only ever lowers retMax: absent/invalid retmax keeps DEFAULT_RETMAX, i.e. today's EFetch.
+        if (retmax != null && retmax > 0 && retmax < pubmedXmlQuery.getRetMax()) {
+            pubmedXmlQuery.setRetMax(retmax);
+        }
 
         String eFetchUrl = pubmedXmlQuery.buildEFetchQuery();
-        log.info("retMax=[{}], pubMedQuery=[{}], numberOfPubmedArticles=[{}], eFetchUrl=[{}].",
-                pubmedXmlQuery.getRetMax(), pubMedQuery, numberOfPubmedArticles,
+        log.info("retMax=[{}], sort=[{}], pubMedQuery=[{}], numberOfPubmedArticles=[{}], eFetchUrl=[{}].",
+                pubmedXmlQuery.getRetMax(), normalizedSort, pubMedQuery, numberOfPubmedArticles,
                 PubmedXmlQuery.redactApiKey(eFetchUrl));
 
         try {
@@ -156,6 +222,33 @@ public class PubMedArticleRetrievalService {
     }
 
     /**
+     * Maps a caller-supplied sort value to the literal value to put on the ESearch wire. Only two
+     * orderings are supported — relevance and publication date — and everything else is ignored
+     * rather than forwarded, because ESearch does not reject an unknown sort key: it silently drops
+     * it and falls back to default order.
+     *
+     * @param sort raw caller input (may be null); {@code relevance}, or {@code date} / {@code pub_date}
+     * @return {@code relevance}, {@code pub_date}, or {@code null} meaning "send no sort parameter"
+     */
+    protected static String normalizeSort(String sort) {
+        if (sort == null || sort.trim().isEmpty()) {
+            return null;
+        }
+        String normalized = sort.trim().toLowerCase(Locale.ROOT);
+        if (SORT_RELEVANCE.equals(normalized)) {
+            return SORT_RELEVANCE;
+        }
+        // Caller-facing "date" is translated to NCBI's actual key, "pub_date" (see SORT_PUB_DATE):
+        // forwarding a literal "date" would be silently ignored by ESearch and yield default order.
+        if (SORT_DATE.equals(normalized) || SORT_PUB_DATE.equals(normalized)) {
+            return SORT_PUB_DATE;
+        }
+        log.warn("Ignoring unsupported ESearch sort value [{}]; expected '{}' or '{}'. "
+                + "Falling back to PubMed's default order.", sort, SORT_RELEVANCE, SORT_DATE);
+        return null;
+    }
+
+    /**
      * Recovery handler invoked when {@link #retrieve(String)} exhausts all retry attempts.
      * Re-throws the final exception rather than silently swallowing it so callers still see
      * the failure, but provides a single, well-defined termination point for the retry loop.
@@ -166,8 +259,28 @@ public class PubMedArticleRetrievalService {
         throw e;
     }
 
+    /**
+     * Recovery handler for {@link #retrieve(String, String, Integer)}. Spring Retry selects the
+     * {@code @Recover} method whose argument arity matches the failing {@code @Retryable} method,
+     * so this overload must exist alongside {@link #recoverRetrieve(IOException, String)}.
+     */
+    @Recover
+    public List<PubMedArticle> recoverRetrieve(IOException e, String pubMedQuery, String sort, Integer retmax) throws IOException {
+        log.error("Exhausted retries retrieving PubMed articles for query=[{}], sort=[{}], retmax=[{}].",
+                pubMedQuery, sort, retmax, e);
+        throw e;
+    }
+
     public PubmedESearchResult getNumberOfPubMedArticles(String query) throws IOException {
         return executeESearch(query);
+    }
+
+    /**
+     * Sort-aware ESearch. Kept separate from {@link #getNumberOfPubMedArticles(String)} so the
+     * unsorted path continues to run through the exact same call chain as before.
+     */
+    public PubmedESearchResult getNumberOfPubMedArticles(String query, String sort) throws IOException {
+        return executeESearch(query, sort);
     }
 
     /**
@@ -182,8 +295,23 @@ public class PubMedArticleRetrievalService {
      *         non-JSON (e.g. HTML error page) responses.
      */
     protected PubmedESearchResult executeESearch(String term) throws IOException {
+        return executeESearch(term, null);
+    }
+
+    /**
+     * Sort-aware {@link #executeESearch(String)}.
+     * <p>
+     * The {@code sort} parameter is appended <em>last</em> and only when non-null, so when no sort
+     * is requested the form-encoded request body is byte-identical to the one this method emitted
+     * before sort support existed. The ReCiter engine is this tool's primary caller and must not
+     * see any change in behavior.
+     *
+     * @param sort already-normalized sort value ({@code relevance}, {@code date}, or {@code null})
+     */
+    protected PubmedESearchResult executeESearch(String term, String sort) throws IOException {
         PubmedXmlQuery pubmedXmlQuery = new PubmedXmlQuery(term);
         pubmedXmlQuery.setRetStart(0);
+        pubmedXmlQuery.setSort(sort);
 
         // The request is an HTTP POST to ESEARCH_BASE_URL with form-encoded params; log the
         // endpoint actually called (with api_key redacted) and the term, not a discarded GET URL.
@@ -193,7 +321,7 @@ public class PubMedArticleRetrievalService {
         } else {
             postUrl = PubmedXmlQuery.ESEARCH_BASE_URL;
         }
-        log.info("ESearch POST url=[{}], term=[{}]", PubmedXmlQuery.redactApiKey(postUrl), term);
+        log.info("ESearch POST url=[{}], term=[{}], sort=[{}]", PubmedXmlQuery.redactApiKey(postUrl), term, sort);
 
         PubmedESearchResult eSearchResult = new PubmedESearchResult();
 
@@ -206,6 +334,10 @@ public class PubMedArticleRetrievalService {
         params.add(new BasicNameValuePair("term", java.net.URLDecoder.decode(pubmedXmlQuery.getTerm(), "UTF-8")));
         params.add(new BasicNameValuePair("retmode", pubmedXmlQuery.getRetMode()));
         params.add(new BasicNameValuePair("retstart", String.valueOf(pubmedXmlQuery.getRetStart())));
+        // Appended last and only when present: an absent sort leaves the body byte-identical.
+        if (pubmedXmlQuery.getSort() != null && !pubmedXmlQuery.getSort().isEmpty()) {
+            params.add(new BasicNameValuePair("sort", pubmedXmlQuery.getSort()));
+        }
         httppost.setEntity(new UrlEncodedFormEntity(params));
         httppost.setHeader("Content-Type", "application/x-www-form-urlencoded");
         httppost.setHeader("cache-control", "no-cache");


### PR DESCRIPTION
## Why

`/pubmed/query-complex/` could only return **the first N matches in PubMed's default order**. A caller who wants *"the 50 most relevant of 24,852"* had no way to ask for it — and no way to know they hadn't got it.

This blocks ReCiter Publication Manager's Literature Search (RPM #824), whose Issue-review and Clinical-question modes retrieve the **top 50 by relevance**. Against a jar without these fields, `{sort, retmax}` are **silently ignored** — Jackson does not fail on unknown properties — so the page would print *"top 50 by most relevant"* over an **unranked slice**. That is the exact class of confident-but-wrong output the feature exists to prevent, which is why this ships **before** RPM, or not at all.

## What

Two optional fields on the existing `PubMedQuery` body. **Both absent → the emitted ESearch request is byte-identical to before**, and the no-sort path dispatches through the *original* single-argument service method, so the ReCiter engine's path is provably unchanged.

| Field | Meaning |
|---|---|
| `sort` | `relevance` or `date`. Anything else → no sort parameter at all (never a guess). |
| `retmax` | Caps how many records EFetch pulls back. A **cap, never an increase** — a value above the default is ignored. |

Sort is applied to the **ESearch**, not the EFetch: the tool searches with `usehistory=y`, so the ESearch is what posts the ordered result set to the history server, and EFetch then walks that `WebEnv` from `retstart=0`. Sorting at search time plus a `retmax` cap at fetch time is what actually yields "the top N by relevance".

## The trap this had to avoid

**`sort=date` is silently ignored by NCBI.** ESearch's publication-date key is `pub_date`; a literal `sort=date` returns an idlist **byte-identical to sending no sort at all** — and identical to sending a garbage value. Forwarding the caller's `date` verbatim would have reproduced the precise failure this parameter exists to fix: ask for a ranked result, silently get default order. So `date` is accepted from callers and **mapped to `pub_date`** on the wire.

## The threshold carve-out

Previously a query matching more than the 2,000 retrieval threshold was hard-refused. With an explicit `retmax` (≤ threshold), the fetch is bounded by `retmax` **regardless of how many articles matched** — "the 50 most relevant of 2.6 million" is a narrow fetch over a broad search, and it is now possible. **Without** `retmax`, matched == fetched and the refusal fires exactly as before.

## Verified against live PubMed, through the running jar

| | |
|---|---|
| `retmax=5` / `retmax=50` | 5 / 50 records — the cap is honoured |
| `sort=relevance` vs `sort=date` | **different first record** (2023 vs 2026) — the sort genuinely reorders, which is the proof `pub_date` reached the wire |
| broad query (2.6M matches) + `retmax=50` | **HTTP 200**, records returned — the carve-out works |
| same broad query, **no** `retmax` | still hard-refused — the legacy path is untouched |
| engine path (no sort, no retmax) | unchanged |

**20 tests, 0 failures.** Rebased onto current `dev` (the original branch was cut from `master`).

## Two things found while verifying — NEITHER caused by this PR

1. **The threshold refusal surfaces as `500`, not the `502` `GlobalExceptionHandler` intends.** The refusal is an `IOException` thrown inside a `@Retryable` method, so Spring Retry burns all 7 attempts on a permanent condition (the matched count will not shrink) and then wraps it — `@ExceptionHandler(IOException.class)` never sees it, and the catch-all returns 500. **Confirmed against an unmodified `dev` build**, so it predates this change. Deliberately not fixed here: changing the retry/error semantics of the engine's own retrieval path does not belong in a change about sort and retmax. Worth its own issue.
2. **`retmax` caps the EFetch, and the parsed count can be lower.** `cancer[tiab]` with `retmax=50` yields **46** — the SAX parser deliberately skips `<PubmedBookArticle>` records, and that batch contained 4 book chapters. A query with no book records returns exactly 50. Pre-existing parser behaviour; callers should treat `retmax` as "fetch at most N", not "return exactly N".