### PR TITLE
fix(pubmed): a too-broad query is a 502, not a 500 — and it must not cost seven ESearch calls

### DIFF
--- a/src/main/java/reciter/controller/GlobalExceptionHandler.java
+++ b/src/main/java/reciter/controller/GlobalExceptionHandler.java
@@ -10,26 +10,46 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import lombok.extern.slf4j.Slf4j;
+import reciter.pubmed.retriever.PubMedRetrievalException;
+import reciter.pubmed.retriever.RetrievalThresholdExceededException;
 
 /**
  * Global exception handler producing clean JSON error responses without leaking stack traces
  * or internal exception detail to clients. Stack traces are logged server-side only.
  *
- * <p>The threshold-exceeded case (thrown as an {@link IOException} by
+ * <p>The threshold-exceeded case ({@link RetrievalThresholdExceededException}, thrown by
  * {@code PubMedArticleRetrievalService.retrieve} when the matching article count exceeds the
  * retrieval threshold) is mapped to {@code 502 Bad Gateway} with a small {@code {error, message}}
  * body so callers can distinguish it from a generic failure. All other uncaught exceptions are
  * mapped to a generic {@code 500 Internal Server Error} body with no internal detail.
+ *
+ * <p>A retrieval failure arrives here by ONE OF TWO ROUTES, and both must land in the same place:
+ * directly as an {@link IOException} (nothing retried it), or as a {@link PubMedRetrievalException}
+ * (Spring Retry gave up and the {@code @Recover} rethrew — unchecked, because a checked rethrow
+ * from a reflectively-invoked {@code @Recover} gets wrapped in an {@code UndeclaredThrowableException}
+ * and never reaches the {@code IOException} handler at all; that is the bug this fixes). They share
+ * {@link #classify} so the two routes cannot drift apart and quietly answer differently.
  */
 @Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
-    /** Marker substring identifying the threshold-exceeded IOException message. */
+    /** Marker substring identifying the threshold-exceeded message. */
     private static final String THRESHOLD_EXCEEDED_MARKER = "exceeded the threshold level";
 
+    /** Not retried, so it arrives directly. */
     @ExceptionHandler(IOException.class)
     public ResponseEntity<Map<String, Object>> handleIOException(IOException ex) {
+        return classify(ex);
+    }
+
+    /** Retried, exhausted, and rethrown by {@code @Recover}. Same failure, different route. */
+    @ExceptionHandler(PubMedRetrievalException.class)
+    public ResponseEntity<Map<String, Object>> handleRetrievalException(PubMedRetrievalException ex) {
+        return classify(ex);
+    }
+
+    private static ResponseEntity<Map<String, Object>> classify(Throwable ex) {
         String message = ex.getMessage();
         if (message != null && message.contains(THRESHOLD_EXCEEDED_MARKER)) {
             log.warn("PubMed retrieval threshold exceeded: {}", message);

--- a/src/main/java/reciter/pubmed/retriever/PubMedArticleRetrievalService.java
+++ b/src/main/java/reciter/pubmed/retriever/PubMedArticleRetrievalService.java
@@ -127,8 +127,8 @@ public class PubMedArticleRetrievalService {
      * (2,000), well below {@link PubmedXmlQuery#DEFAULT_RETMAX} (10,000), by one of two routes:
      * <ul>
      *   <li>no {@code retmax}: matched == fetched, so a query matching more than the threshold is
-     *       hard-refused with an {@link IOException}. This is the legacy path the ReCiter engine
-     *       takes, and it is unchanged.</li>
+     *       hard-refused with a {@link RetrievalThresholdExceededException}. This is the legacy path
+     *       the ReCiter engine takes, and it is unchanged.</li>
      *   <li>an explicit {@code retmax} (&le; the threshold): the fetch is bounded by {@code retmax}
      *       regardless of how many articles matched, so the matched-count refusal does not apply —
      *       "the 50 most relevant of 24,852" is a narrow fetch over a broad search.</li>
@@ -136,15 +136,14 @@ public class PubMedArticleRetrievalService {
      * The refusal message text is matched by {@code GlobalExceptionHandler}'s
      * {@code THRESHOLD_EXCEEDED_MARKER}, so it must not change.
      * <p>
-     * That mapping does NOT currently reach the caller, and the bug predates this change: because
-     * the refusal is an {@link IOException} thrown from inside a {@code @Retryable} method, Spring
-     * Retry exhausts all 7 attempts on it (a permanent condition — the count will not shrink) and
-     * then wraps it, so {@code @ExceptionHandler(IOException.class)} never sees it and the catch-all
-     * returns <strong>500, not 502</strong>. Verified against an unmodified {@code dev} build.
-     * Reported separately; deliberately NOT fixed here, because changing the retry/error semantics
-     * of the engine's own retrieval path does not belong in a change about sort and retmax.
+     * THE REFUSAL IS EXCLUDED FROM RETRY, and that is not a tuning preference. It is PERMANENT: the
+     * matched count is a property of the query, not of the network, so retrying cannot make it
+     * smaller. As a plain {@code IOException} it was exactly what this retry policy retries — so one
+     * too-broad query fired SEVEN ESearch requests at NCBI, with backoff, before failing with an
+     * answer it already had on the first attempt. NCBI's unkeyed limit is 3 requests/second.
      */
     @Retryable(maxAttempts = 7, value = IOException.class,
+        exclude = RetrievalThresholdExceededException.class,
         backoff = @Backoff(random = true, delay = 1500, maxDelay = 9000), listeners = {"retryListener"})
     public List<PubMedArticle> retrieve(String pubMedQuery) throws IOException {
         return doRetrieve(pubMedQuery, null, null);
@@ -163,6 +162,7 @@ public class PubMedArticleRetrievalService {
      *                    leaves the default retmax in place. This is a cap, never an increase.
      */
     @Retryable(maxAttempts = 7, value = IOException.class,
+        exclude = RetrievalThresholdExceededException.class,
         backoff = @Backoff(random = true, delay = 1500, maxDelay = 9000), listeners = {"retryListener"})
     public List<PubMedArticle> retrieve(String pubMedQuery, String sort, Integer retmax) throws IOException {
         return doRetrieve(pubMedQuery, sort, retmax);
@@ -206,7 +206,9 @@ public class PubMedArticleRetrievalService {
         // ReCiter engine, every legacy path) keep the original matched-count refusal untouched.
         boolean fetchIsBounded = retmax != null && retmax > 0 && retmax <= RETRIEVAL_THRESHOLD;
         if (!fetchIsBounded && numberOfPubmedArticles > RETRIEVAL_THRESHOLD) {
-            throw new IOException("Number of PubMed Articles retrieved " + numberOfPubmedArticles + " exceeded the threshold level " + RETRIEVAL_THRESHOLD);
+            // PERMANENT, and typed as such: the matched count is a property of the query, so no
+            // amount of retrying will shrink it. See RetrievalThresholdExceededException.
+            throw new RetrievalThresholdExceededException("Number of PubMed Articles retrieved " + numberOfPubmedArticles + " exceeded the threshold level " + RETRIEVAL_THRESHOLD);
         }
 
         // No matches: return empty without an EFetch round-trip (the old pagination loop, gated on
@@ -279,11 +281,20 @@ public class PubMedArticleRetrievalService {
      * Recovery handler invoked when {@link #retrieve(String)} exhausts all retry attempts.
      * Re-throws the final exception rather than silently swallowing it so callers still see
      * the failure, but provides a single, well-defined termination point for the retry loop.
+     * <p>
+     * IT RETHROWS AN <strong>UNCHECKED</strong> EXCEPTION, DELIBERATELY. Spring Retry invokes this
+     * method REFLECTIVELY, and {@code ReflectionUtils} wraps any CHECKED exception thrown by a
+     * reflectively-invoked method in an {@code UndeclaredThrowableException} — a RuntimeException.
+     * Rethrowing the {@code IOException} directly therefore hid it inside a wrapper that
+     * {@code @ExceptionHandler(IOException.class)} could not see, the catch-all handler caught it
+     * instead, and every threshold refusal was served as <strong>500 "An unexpected error
+     * occurred"</strong> rather than the 502 it was carefully mapped to. See
+     * {@link PubMedRetrievalException}. Do not turn this back into {@code throw e}.
      */
     @Recover
-    public List<PubMedArticle> recoverRetrieve(IOException e, String pubMedQuery) throws IOException {
+    public List<PubMedArticle> recoverRetrieve(IOException e, String pubMedQuery) {
         log.error("Exhausted retries retrieving PubMed articles for query=[{}].", pubMedQuery, e);
-        throw e;
+        throw new PubMedRetrievalException(e);
     }
 
     /**
@@ -292,10 +303,13 @@ public class PubMedArticleRetrievalService {
      * so this overload must exist alongside {@link #recoverRetrieve(IOException, String)}.
      */
     @Recover
-    public List<PubMedArticle> recoverRetrieve(IOException e, String pubMedQuery, String sort, Integer retmax) throws IOException {
+    public List<PubMedArticle> recoverRetrieve(IOException e, String pubMedQuery, String sort, Integer retmax) {
         log.error("Exhausted retries retrieving PubMed articles for query=[{}], sort=[{}], retmax=[{}].",
                 pubMedQuery, sort, retmax, e);
-        throw e;
+        // UNCHECKED, for the same reason as the two-argument overload above — a checked rethrow from
+        // a reflectively-invoked @Recover is wrapped in an UndeclaredThrowableException and lands in
+        // the catch-all as a 500. See PubMedRetrievalException.
+        throw new PubMedRetrievalException(e);
     }
 
     public PubmedESearchResult getNumberOfPubMedArticles(String query) throws IOException {

--- a/src/main/java/reciter/pubmed/retriever/PubMedRetrievalException.java
+++ b/src/main/java/reciter/pubmed/retriever/PubMedRetrievalException.java
@@ -1,0 +1,38 @@
+package reciter.pubmed.retriever;
+
+import java.io.IOException;
+
+/**
+ * What a failed retrieval throws once Spring Retry has given up on it.
+ *
+ * <p><strong>UNCHECKED, AND IT HAS TO BE. THIS IS THE 500-INSTEAD-OF-502 BUG.</strong>
+ *
+ * <p>Spring Retry invokes a {@code @Recover} method <em>reflectively</em>
+ * ({@code RecoverAnnotationRecoveryHandler} → {@code ReflectionUtils.invokeMethod}). When a
+ * reflectively-invoked method throws a <em>checked</em> exception, {@code ReflectionUtils} wraps it
+ * in a {@link java.lang.reflect.UndeclaredThrowableException} — which is a {@code RuntimeException}.
+ * So a {@code @Recover} that rethrew the original {@link IOException} produced this:
+ *
+ * <pre>
+ *   UndeclaredThrowableException          &lt;- what Spring MVC actually sees
+ *     └─ caused by IOException("... exceeded the threshold level 2000")
+ * </pre>
+ *
+ * <p>{@code @ExceptionHandler(IOException.class)} therefore never saw it, the catch-all
+ * {@code @ExceptionHandler(Exception.class)} caught it instead, and a deliberate, well-formed
+ * "your query is too broad" refusal was served to the caller as <strong>500 internal_error — "An
+ * unexpected error occurred"</strong>. The 502 mapping had been dead the whole time, and it was
+ * invisible because the log line looked correct.
+ *
+ * <p>Throwing an UNCHECKED exception from {@code @Recover} is what keeps the type intact across
+ * that reflective boundary, so the handler can see it and classify it. Do not "simplify" this back
+ * into a checked rethrow.
+ */
+public class PubMedRetrievalException extends RuntimeException {
+
+	private static final long serialVersionUID = 1L;
+
+	public PubMedRetrievalException(IOException cause) {
+		super(cause.getMessage(), cause);
+	}
+}

--- a/src/main/java/reciter/pubmed/retriever/RetrievalThresholdExceededException.java
+++ b/src/main/java/reciter/pubmed/retriever/RetrievalThresholdExceededException.java
@@ -1,0 +1,27 @@
+package reciter.pubmed.retriever;
+
+import java.io.IOException;
+
+/**
+ * The query matched more PubMed articles than this tool is willing to retrieve.
+ *
+ * <p><strong>This is a PERMANENT condition, and that is the whole reason the type exists.</strong>
+ * The matched count is a property of the query, not of the network: retrying it cannot make the
+ * number smaller. It was previously thrown as a plain {@link IOException} from inside a
+ * {@code @Retryable} method whose retry policy is {@code IOException}, so a too-broad query was
+ * retried <strong>seven times</strong>, with backoff — seven pointless ESearch calls to NCBI, whose
+ * unkeyed rate limit is 3 requests/second, for an answer that was never going to change. Giving the
+ * refusal its own type is what lets {@code @Retryable} exclude it and fail on the first attempt.
+ *
+ * <p>It stays an {@link IOException} subclass so that every existing {@code throws IOException}
+ * signature and {@code catch (IOException)} block continues to see it, and so that
+ * {@code GlobalExceptionHandler}'s message-marker match keeps working unchanged.
+ */
+public class RetrievalThresholdExceededException extends IOException {
+
+	private static final long serialVersionUID = 1L;
+
+	public RetrievalThresholdExceededException(String message) {
+		super(message);
+	}
+}


### PR DESCRIPTION
## Two bugs, one root cause, found while verifying #164

**Stacked on #164** so it can cover that PR's new overloads too — see the last section. GitHub will retarget this to `dev` automatically once #164 merges.

### 1. Every threshold refusal was served as `500 internal_error`

`GlobalExceptionHandler` carefully maps the "too many articles" refusal to **502 `threshold_exceeded`** with an actionable message. **That mapping has been dead.** Callers got:

```
500  {"error":"internal_error","message":"An unexpected error occurred while processing the request."}
```

The cause is subtle and worth writing down, because it is invisible in the logs (the server-side log line looks perfectly correct):

> Spring Retry invokes `@Recover` **reflectively**. When a reflectively-invoked method throws a **checked** exception, `ReflectionUtils` wraps it in an **`UndeclaredThrowableException`** — a `RuntimeException`. So `@Recover`'s `throw e` (an `IOException`) arrived at Spring MVC as `UndeclaredThrowableException`, `@ExceptionHandler(IOException.class)` never saw it, and the catch-all `@ExceptionHandler(Exception.class)` answered instead.

**Fix:** `@Recover` now rethrows an **unchecked** `PubMedRetrievalException`, which survives the reflective boundary with its type intact. The handler classifies both routes — a direct `IOException` and a post-retry `PubMedRetrievalException` — through one shared method so they cannot drift apart.

### 2. A permanently-doomed query hammered NCBI seven times

The refusal was a plain `IOException`, and the retry policy is `@Retryable(value = IOException.class, maxAttempts = 7)`. But **the matched count is a property of the query, not of the network** — retrying cannot make it smaller. So one too-broad query fired **seven ESearch requests** at NCBI, with backoff, before failing with the answer it already had on the first attempt. NCBI's unkeyed limit is **3 requests/second**.

**Fix:** the refusal gets its own type, `RetrievalThresholdExceededException extends IOException`, and the retry policy `exclude`s it. It still subclasses `IOException`, so every existing `throws`/`catch` and the handler's message-marker match keep working unchanged.

## Measured, before and after

| | before | after |
|---|---|---|
| Status | `500 internal_error` — "An unexpected error occurred" | **`502 threshold_exceeded`** — "The query matched too many PubMed articles to retrieve. Please refine the query." |
| Time to fail | **~30s** (7 attempts × backoff) | **~1s** |
| ESearch calls to NCBI | **7** | **1** |

Verified against a live build, on **both** retrieval paths:

| Request | Result |
|---|---|
| `cancer[tiab]`, no retmax (legacy engine path) | **502** `threshold_exceeded`, 0.86s |
| `cancer[tiab]`, `sort=relevance` (#164's new overload) | **502** `threshold_exceeded`, 1.34s |
| `cancer[tiab]`, `sort=relevance`, `retmax=5` | **200**, records — #164's carve-out still works |
| a normal query, and the engine's no-sort path | unchanged |

**20 tests, 0 failures.** Retry remains fully enabled for genuine transient `IOException`s — only the *permanent* refusal is excluded.

## Why this is stacked on #164 rather than cut from `dev`

#164 adds a **second** `@Retryable` overload and a **second** `@Recover`. Fixing only the code on `dev` would have merged #164 straight back into both bugs on its new path — a sorted request would still have burned 7 retries and still returned a 500. Both overloads and both recovery methods are fixed here.