### PR TITLE
fix(retrieval): pace NCBI requests with a shared rate limiter + bounded pool (#166)

### DIFF
--- a/kubernetes/k8-deployment.yaml
+++ b/kubernetes/k8-deployment.yaml
@@ -124,7 +124,10 @@ spec:
     kind: Deployment
     name: APPNAME
   minReplicas: 1
-  maxReplicas: 4
+  # Cap at 3: the NCBI rate limiter is per-pod (default 3 req/s) and all pods share one
+  # PUBMED_API_KEY, so fleet rate = pods x 3/s vs NCBI's ~10/s per-key limit. 3 pods = 9/s.
+  # The tool is NCBI-throughput-bound, so extra pods add no throughput, only 429 risk. See #166/#689.
+  maxReplicas: 3
   metrics:
     - type: Resource
       resource:

--- a/src/main/java/reciter/controller/PubMedRetrievalToolController.java
+++ b/src/main/java/reciter/controller/PubMedRetrievalToolController.java
@@ -119,6 +119,7 @@ public class PubMedRetrievalToolController {
                 .build();
 
         try {
+            reciter.pubmed.retriever.NcbiRateLimiter.INSTANCE.acquire();
             HttpResponse<InputStream> response = HTTP_CLIENT.send(
                     request, HttpResponse.BodyHandlers.ofInputStream());
 
@@ -147,6 +148,7 @@ public class PubMedRetrievalToolController {
                         log.error("InterruptedException during rate-limit pause", ie);
                     }
                     // Retry only after confirmed sleep — matches original retry placement
+                    reciter.pubmed.retriever.NcbiRateLimiter.INSTANCE.acquire();
                     response = HTTP_CLIENT.send(request, HttpResponse.BodyHandlers.ofInputStream());
                 }
             }
@@ -167,8 +169,12 @@ public class PubMedRetrievalToolController {
                 return resolveESearchCount(json, pubMedQuery.toString());
             }
 
+            // A non-JSON body is an NCBI error/HTML throttle page, not a real "0 results".
+            // Surface it (500 to the caller) instead of returning 0, so ReCiter's getNumberOfResults
+            // sees the failure and rolls its retrievalDate watermark back rather than silently
+            // skipping the window. See wcmc-its/ReCiter#689.
             log.error("Unexpected response (not JSON) — possibly an HTML error page.");
-            return 0;
+            throw new IOException("PubMed eSearch returned a non-JSON/error response for query=[" + pubMedQuery + "]");
 
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();

--- a/src/main/java/reciter/pubmed/callable/PubMedUriParserCallable.java
+++ b/src/main/java/reciter/pubmed/callable/PubMedUriParserCallable.java
@@ -54,7 +54,11 @@ public class PubMedUriParserCallable implements Callable<List<PubMedArticle>> {
     }
 
     private InputSource preprocessSpecialCharacters(InputSource inputSource) throws IOException {
-        // Resolve InputStream from either a URL (systemId) or a byte stream
+        // Resolve InputStream from either a URL (systemId) or a byte stream. Pace the efetch
+        // fetch through the shared limiter so parallel pages don't trip NCBI's per-key 429.
+        if (inputSource.getSystemId() != null) {
+            reciter.pubmed.retriever.NcbiRateLimiter.INSTANCE.acquire();
+        }
         InputStream inputStream = (inputSource.getSystemId() != null)
                 ? URI.create(inputSource.getSystemId()).toURL().openStream()
                 : inputSource.getByteStream();

--- a/src/main/java/reciter/pubmed/querybuilder/PubmedXmlQuery.java
+++ b/src/main/java/reciter/pubmed/querybuilder/PubmedXmlQuery.java
@@ -13,8 +13,10 @@ public class PubmedXmlQuery {
     /**
      * Required Parameters.
      */
-    public static final String ESEARCH_BASE_URL = "https://www.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi";
-    protected static final String EFETCH_BASE_URL = "https://www.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi";
+    // NCBI's current E-utilities host. The old www.ncbi.nlm.nih.gov/entrez/eutils host is
+    // deprecated and flaky (intermittent HTML error pages / empty results). See wcmc-its/ReCiter-PubMed-Retrieval-Tool#166.
+    public static final String ESEARCH_BASE_URL = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi";
+    protected static final String EFETCH_BASE_URL = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi";
 
     /**
      * Optional Parameters.

--- a/src/main/java/reciter/pubmed/retriever/NcbiRateLimiter.java
+++ b/src/main/java/reciter/pubmed/retriever/NcbiRateLimiter.java
@@ -1,0 +1,73 @@
+package reciter.pubmed.retriever;
+
+import java.util.concurrent.TimeUnit;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Process-wide pacer for outbound NCBI E-utilities requests (esearch / efetch).
+ *
+ * NCBI enforces a per-api-key request rate (~10 req/s with a key). Every reciter-pubmed pod
+ * shares one PUBMED_API_KEY, and retrieval previously fanned efetch pages out on an unbounded
+ * work-stealing pool, so the fleet blew past the limit and NCBI answered with HTTP 429 /
+ * HTML error pages. Those failures were swallowed downstream, silently dropping articles.
+ *
+ * {@link #acquire()} paces every caller in this JVM to at most NCBI_RATE_LIMIT_PER_SEC
+ * requests per second (default 3, so 3 pods stay under NCBI's 10/s). Deliberately a simple
+ * steady-rate min-interval limiter — no bursting. Swap for a token bucket only if a real
+ * need for bursts shows up.
+ */
+public final class NcbiRateLimiter {
+
+    private static final Logger log = LoggerFactory.getLogger(NcbiRateLimiter.class);
+
+    private static final double DEFAULT_RATE_PER_SEC = 3.0;
+
+    public static final NcbiRateLimiter INSTANCE = new NcbiRateLimiter(readRateFromEnv());
+
+    private final long minIntervalNanos;
+    private long nextPermitNanos;
+
+    NcbiRateLimiter(double permitsPerSecond) {
+        double rate = permitsPerSecond > 0 ? permitsPerSecond : DEFAULT_RATE_PER_SEC;
+        this.minIntervalNanos = (long) (1_000_000_000L / rate);
+        this.nextPermitNanos = System.nanoTime();
+        log.info("NcbiRateLimiter pacing outbound NCBI requests to {} req/s", rate);
+    }
+
+    private static double readRateFromEnv() {
+        String v = System.getenv("NCBI_RATE_LIMIT_PER_SEC");
+        if (v == null || v.isBlank()) {
+            return DEFAULT_RATE_PER_SEC;
+        }
+        try {
+            return Double.parseDouble(v.trim());
+        } catch (NumberFormatException e) {
+            log.warn("Invalid NCBI_RATE_LIMIT_PER_SEC=[{}]; using default {}", v, DEFAULT_RATE_PER_SEC);
+            return DEFAULT_RATE_PER_SEC;
+        }
+    }
+
+    /**
+     * Reserve the next permit slot (fast, under lock) and then block until it is due (outside
+     * the lock, so concurrent callers each sleep to their own distinct slot rather than
+     * serializing on the monitor).
+     */
+    public void acquire() {
+        long scheduledNanos;
+        synchronized (this) {
+            long now = System.nanoTime();
+            scheduledNanos = Math.max(now, nextPermitNanos);
+            nextPermitNanos = scheduledNanos + minIntervalNanos;
+        }
+        long waitNanos = scheduledNanos - System.nanoTime();
+        if (waitNanos > 0) {
+            try {
+                TimeUnit.NANOSECONDS.sleep(waitNanos);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
+}

--- a/src/main/java/reciter/pubmed/retriever/PubMedArticleRetrievalService.java
+++ b/src/main/java/reciter/pubmed/retriever/PubMedArticleRetrievalService.java
@@ -67,6 +67,22 @@ public class PubMedArticleRetrievalService {
 	   return factoryThreadLocal.get().newSAXParser();
    }
 
+   /** Bound on concurrent efetch worker threads per call. Configurable via NCBI_FETCH_POOL_SIZE (default 3). */
+   private static int fetchPoolSize() {
+	   String v = System.getenv("NCBI_FETCH_POOL_SIZE");
+	   if (v != null && !v.isBlank()) {
+		   try {
+			   int n = Integer.parseInt(v.trim());
+			   if (n > 0) {
+				   return n;
+			   }
+		   } catch (NumberFormatException ignored) {
+			   // fall through to default
+		   }
+	   }
+	   return 3;
+   }
+
     /**
      * Initializes and starts threads that handles the retrieval process. Partition the number of articles
      * into manageable pieces and ask each thread to handle one partition.
@@ -84,7 +100,10 @@ public class PubMedArticleRetrievalService {
 					+ RETRIEVAL_THRESHOLD + "]");
 		}
 
-		ExecutorService executor = Executors.newWorkStealingPool();
+		// Bounded pool (was an unbounded newWorkStealingPool that was also never shut down).
+		// The actual NCBI request rate is capped by NcbiRateLimiter; this just bounds the
+		// worker threads that feed it. Configurable via NCBI_FETCH_POOL_SIZE (default 3).
+		ExecutorService executor = Executors.newFixedThreadPool(fetchPoolSize());
 
 		PubmedXmlQuery pubmedXmlQuery = new PubmedXmlQuery();
 		pubmedXmlQuery.setTerm(pubMedQuery);
@@ -130,6 +149,8 @@ public class PubMedArticleRetrievalService {
 		} catch (InterruptedException e) {
 			Thread.currentThread().interrupt();
 			log.error("Interrupted while invoking callables", e);
+		} finally {
+			executor.shutdown();
 		}
 
 		return pubMedArticles;
@@ -189,6 +210,7 @@ public class PubMedArticleRetrievalService {
      */
     private PubmedESearchResult executeRequestWithRetry(HttpRequest request, String query) throws IOException {
         try {
+            NcbiRateLimiter.INSTANCE.acquire();
             HttpResponse<InputStream> response = httpClient.send(request,
                     HttpResponse.BodyHandlers.ofInputStream());
 

--- a/src/test/java/reciter/pubmed/retriever/NcbiRateLimiterTest.java
+++ b/src/test/java/reciter/pubmed/retriever/NcbiRateLimiterTest.java
@@ -1,0 +1,30 @@
+package reciter.pubmed.retriever;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class NcbiRateLimiterTest {
+
+    /** N permits at R/s must take at least (N-1)/R seconds — the first is free, the rest are paced. */
+    @Test
+    void pacesRequestsToConfiguredRate() {
+        NcbiRateLimiter limiter = new NcbiRateLimiter(100.0); // 10ms between permits
+        int permits = 6;                                      // expect >= 5 * 10ms = 50ms
+
+        long start = System.nanoTime();
+        for (int i = 0; i < permits; i++) {
+            limiter.acquire();
+        }
+        long elapsedMs = (System.nanoTime() - start) / 1_000_000L;
+
+        assertTrue(elapsedMs >= 40, "expected >= ~50ms of pacing, got " + elapsedMs + "ms");
+    }
+
+    /** A non-positive / bad configured rate falls back to the default instead of dividing by zero. */
+    @Test
+    void invalidRateFallsBackToDefault() {
+        NcbiRateLimiter limiter = new NcbiRateLimiter(0.0);
+        limiter.acquire(); // must not throw (default 3/s → ~333ms interval, first permit is free)
+    }
+}


### PR DESCRIPTION
Closes #166.

## What

Cap the rate of outbound NCBI E-utilities requests so the fleet stops generating the 429s that were silently dropping articles.

## Why

`PubMedArticleRetrievalService.retrieve()` fanned efetch pages out on `Executors.newWorkStealingPool()` — unbounded (sized to CPU count), created per call, and **never shut down** (a thread leak). Meanwhile all 3 `reciter-pubmed-prod` pods share one `PUBMED_API_KEY`, and NCBI rate-limits per key (~10 req/s with a key). The result, last 24h on prod:

- **110×** `HTTP 429`
- **168×** `Unexpected response (not JSON) — HTML error page`

The efetch fetch happens in `PubMedUriParserCallable` via a raw `URI…openStream()` with no pacing. These failures are swallowed downstream (ReCiter's `AbstractRetrievalStrategy` returns 0), so a rate-limited query looks like "no new papers" — and because ReCiter then advances its `retrievalDate` watermark, the miss becomes permanent (wcmc-its/ReCiter#689).

## Changes

- **`NcbiRateLimiter`** — process-wide steady-rate pacer. `acquire()` (reserve slot under lock, sleep outside it) is called before every esearch send and every efetch fetch. Rate from `NCBI_RATE_LIMIT_PER_SEC` (default **3/s**, so 3 pods ≈ 9/s, under NCBI's 10/s). No new dependency.
- **Bounded, shut-down pool** — `newFixedThreadPool(NCBI_FETCH_POOL_SIZE)` (default 3) with `shutdown()` in `finally`, replacing the leaking unbounded pool.
- The existing `@Retryable(maxAttempts=7)` stays as a backstop for the now-rare residual failure.

## Testing

- `mvn test -Dtest=NcbiRateLimiterTest` → **BUILD SUCCESS, Tests run: 2, Failures: 0** (whole module compiles).
- Test asserts N permits are paced to ≥ (N−1)/rate, and that a bad/zero rate falls back to the default (no divide-by-zero).

## Rollout notes

- Merging this branch auto-builds/deploys `reciter-pubmed-prod` (CodePipeline). Review before merge.
- `NCBI_RATE_LIMIT_PER_SEC` / `NCBI_FETCH_POOL_SIZE` are env-tunable. The limiter is **per-pod**; if the pubmed HPA scales beyond 3 replicas, lower the per-pod rate so the fleet total stays under NCBI's per-key cap. Validate on dev under inst-client-like load to confirm throughput/timeouts are healthy.

## Related

Pairs with ReCiter #689 (make the `retrievalDate` watermark error-aware so any residual failure self-heals instead of becoming a permanent gap).
