### PR TITLE
Retry NCBI IOException/connection-reset instead of failing on the first attempt

### DIFF
--- a/src/main/java/reciter/ReciterRetryListener.java
+++ b/src/main/java/reciter/ReciterRetryListener.java
@@ -16,7 +16,8 @@ public class ReciterRetryListener implements RetryListener {
 			Throwable throwable) {
 
 		if (throwable != null) {
-			log.error("Retry exhausted. Final exception:", throwable);
+			log.error("Retry exhausted after {} attempt(s). Final exception: {}: {}", context.getRetryCount(),
+					throwable.getClass().getName(), throwable.getMessage(), throwable);
 		}
 	}
 

--- a/src/main/java/reciter/controller/PubMedRetrievalToolController.java
+++ b/src/main/java/reciter/controller/PubMedRetrievalToolController.java
@@ -43,6 +43,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import reciter.model.pubmed.PubMedArticle;
 import reciter.model.pubmed.PubmedESearchResult;
+import reciter.pubmed.NcbiHttp;
 import reciter.pubmed.model.PubMedQuery;
 import reciter.pubmed.querybuilder.PubmedXmlQuery;
 import reciter.pubmed.retriever.PubMedArticleRetrievalService;
@@ -118,68 +119,62 @@ public class PubMedRetrievalToolController {
                 .POST(HttpRequest.BodyPublishers.ofString(formData))
                 .build();
 
-        try {
-            reciter.pubmed.retriever.NcbiRateLimiter.INSTANCE.acquire();
-            HttpResponse<InputStream> response = HTTP_CLIENT.send(
-                    request, HttpResponse.BodyHandlers.ofInputStream());
+        // NcbiHttp.sendWithRetry calls NcbiRateLimiter.INSTANCE.acquire() before every attempt
+        // (including retries) and retries a transient IOException (e.g. a pooled connection NCBI
+        // reset underneath us) instead of failing on the first attempt.
+        HttpResponse<InputStream> response = NcbiHttp.sendWithRetry(HTTP_CLIENT, request, 4);
 
-            // ── Rate-limit handling — matches original condition exactly ──
-            // orElse(-1): absent header → -1 → block never triggers (matches original null/length guard)
-            int rateLimitRemaining = (int) response.headers()
-                    .firstValueAsLong("X-RateLimit-Remaining")
-                    .orElse(-1L);
+        // ── Rate-limit handling — matches original condition exactly ──
+        // orElse(-1): absent header → -1 → block never triggers (matches original null/length guard)
+        int rateLimitRemaining = (int) response.headers()
+                .firstValueAsLong("X-RateLimit-Remaining")
+                .orElse(-1L);
 
-            // Log rate-limit headers when both are present (matches original guard)
-            response.headers().firstValue("X-RateLimit-Limit").ifPresent(limit ->
-                    log.info("Query: {} X-RateLimit-Limit: {} X-RateLimit-Remaining: {}",
-                            pubMedQuery, limit, rateLimitRemaining));
+        // Log rate-limit headers when both are present (matches original guard)
+        response.headers().firstValue("X-RateLimit-Limit").ifPresent(limit ->
+                log.info("Query: {} X-RateLimit-Limit: {} X-RateLimit-Remaining: {}",
+                        pubMedQuery, limit, rateLimitRemaining));
 
-            if (rateLimitRemaining == 0) {
-                // Inner guard: only sleep+retry if Retry-After header is present
-                // matches: headerRetryAfter != null && length > 0 && headerRetryAfter[0] != null
-                OptionalLong retryAfter = response.headers().firstValueAsLong("Retry-After");
-                if (retryAfter.isPresent()) {
-                    long sleepSeconds = retryAfter.getAsLong();
-                    log.info("Rate limit hit. Query: {} Retry-After: {} seconds", pubMedQuery, sleepSeconds);
-                    try {
-                        Thread.sleep(sleepSeconds * 1000L);
-                    } catch (InterruptedException ie) {
-                        Thread.currentThread().interrupt();
-                        log.error("InterruptedException during rate-limit pause", ie);
-                    }
-                    // Retry only after confirmed sleep — matches original retry placement
-                    reciter.pubmed.retriever.NcbiRateLimiter.INSTANCE.acquire();
-                    response = HTTP_CLIENT.send(request, HttpResponse.BodyHandlers.ofInputStream());
+        if (rateLimitRemaining == 0) {
+            // Inner guard: only sleep+retry if Retry-After header is present
+            // matches: headerRetryAfter != null && length > 0 && headerRetryAfter[0] != null
+            OptionalLong retryAfter = response.headers().firstValueAsLong("Retry-After");
+            if (retryAfter.isPresent()) {
+                long sleepSeconds = retryAfter.getAsLong();
+                log.info("Rate limit hit. Query: {} Retry-After: {} seconds", pubMedQuery, sleepSeconds);
+                try {
+                    Thread.sleep(sleepSeconds * 1000L);
+                } catch (InterruptedException ie) {
+                    Thread.currentThread().interrupt();
+                    log.error("InterruptedException during rate-limit pause", ie);
                 }
+                // Retry only after confirmed sleep — matches original retry placement
+                response = NcbiHttp.sendWithRetry(HTTP_CLIENT, request, 4);
             }
-
-            // ── Parse response body ──
-            // readAllBytes() replaces IOUtils.copy() + StringWriter — no Apache Commons IO
-            String responseString = new String(response.body().readAllBytes(), StandardCharsets.UTF_8);
-            log.info("PubMed eSearch raw response: {}", responseString);
-
-            if (responseString != null
-                    && !responseString.isBlank()
-                    && responseString.trim().startsWith("{")
-                    && OBJECT_MAPPER.readTree(responseString).has("esearchresult")) {
-
-                JsonNode json = OBJECT_MAPPER.readTree(responseString).get("esearchresult");
-                log.info("PubMed Response Json: {}", json);
-
-                return resolveESearchCount(json, pubMedQuery.toString());
-            }
-
-            // A non-JSON body is an NCBI error/HTML throttle page, not a real "0 results".
-            // Surface it (500 to the caller) instead of returning 0, so ReCiter's getNumberOfResults
-            // sees the failure and rolls its retrievalDate watermark back rather than silently
-            // skipping the window. See wcmc-its/ReCiter#689.
-            log.error("Unexpected response (not JSON) — possibly an HTML error page.");
-            throw new IOException("PubMed eSearch returned a non-JSON/error response for query=[" + pubMedQuery + "]");
-
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new IOException("HTTP request interrupted for query=[" + pubMedQuery + "]", e);
         }
+
+        // ── Parse response body ──
+        // readAllBytes() replaces IOUtils.copy() + StringWriter — no Apache Commons IO
+        String responseString = new String(response.body().readAllBytes(), StandardCharsets.UTF_8);
+        log.info("PubMed eSearch raw response: {}", responseString);
+
+        if (responseString != null
+                && !responseString.isBlank()
+                && responseString.trim().startsWith("{")
+                && OBJECT_MAPPER.readTree(responseString).has("esearchresult")) {
+
+            JsonNode json = OBJECT_MAPPER.readTree(responseString).get("esearchresult");
+            log.info("PubMed Response Json: {}", json);
+
+            return resolveESearchCount(json, pubMedQuery.toString());
+        }
+
+        // A non-JSON body is an NCBI error/HTML throttle page, not a real "0 results".
+        // Surface it (500 to the caller) instead of returning 0, so ReCiter's getNumberOfResults
+        // sees the failure and rolls its retrievalDate watermark back rather than silently
+        // skipping the window. See wcmc-its/ReCiter#689.
+        log.error("Unexpected response (not JSON) — possibly an HTML error page.");
+        throw new IOException("PubMed eSearch returned a non-JSON/error response for query=[" + pubMedQuery + "]");
     }
 
     private int resolveESearchCount(JsonNode json, String queryForLog) throws IOException {

--- a/src/main/java/reciter/pubmed/NcbiHttp.java
+++ b/src/main/java/reciter/pubmed/NcbiHttp.java
@@ -1,0 +1,74 @@
+package reciter.pubmed;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import reciter.pubmed.retriever.NcbiRateLimiter;
+
+/**
+ * Retries a {@link HttpClient#send} call against NCBI E-utilities when the pooled connection
+ * resets underneath us ({@link IOException}, which covers {@link java.net.http.HttpTimeoutException}
+ * too). NCBI closes idle pooled connections server-side; the next send on that connection fails
+ * with "Connection reset" rather than transparently reconnecting. Every caller of this helper is
+ * an idempotent GET-shaped eutils read, so a blind retry is safe.
+ *
+ * {@link NcbiRateLimiter#INSTANCE}.acquire() is called before EVERY attempt, including retries —
+ * the limiter paces the whole fleet and must not be bypassed just because a request is being
+ * retried.
+ */
+public final class NcbiHttp {
+
+    private static final Logger log = LoggerFactory.getLogger(NcbiHttp.class);
+
+    private static final long INITIAL_BACKOFF_MS = 1500L;
+    private static final long MAX_BACKOFF_MS = 9000L;
+
+    private NcbiHttp() {
+    }
+
+    /**
+     * Sends {@code request} via {@code client}, retrying a transient {@link IOException} up to
+     * {@code maxAttempts} attempts total. Backoff between attempts is
+     * {@code 1.5s * 2^(attempt-1)}, capped at 9s. Rethrows the last {@link IOException} once
+     * attempts are exhausted.
+     */
+    public static HttpResponse<InputStream> sendWithRetry(HttpClient client, HttpRequest request, int maxAttempts)
+            throws IOException {
+        IOException lastFailure = null;
+
+        for (int attempt = 1; attempt <= maxAttempts; attempt++) {
+            NcbiRateLimiter.INSTANCE.acquire();
+            try {
+                return client.send(request, HttpResponse.BodyHandlers.ofInputStream());
+            } catch (IOException e) {
+                lastFailure = e;
+                log.warn("NCBI request attempt {}/{} failed with {}: {}", attempt, maxAttempts,
+                        e.getClass().getSimpleName(), e.getMessage());
+                if (attempt < maxAttempts) {
+                    sleepBackoff(attempt);
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new IOException("Interrupted sending NCBI request to [" + request.uri() + "]", e);
+            }
+        }
+
+        throw lastFailure;
+    }
+
+    private static void sleepBackoff(int attempt) throws IOException {
+        long delayMs = Math.min(MAX_BACKOFF_MS, INITIAL_BACKOFF_MS * (1L << (attempt - 1)));
+        try {
+            Thread.sleep(delayMs);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IOException("Interrupted during NCBI retry backoff", e);
+        }
+    }
+}

--- a/src/main/java/reciter/pubmed/retriever/PubMedArticleRetrievalService.java
+++ b/src/main/java/reciter/pubmed/retriever/PubMedArticleRetrievalService.java
@@ -34,6 +34,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import reciter.model.pubmed.PubMedArticle;
 import reciter.model.pubmed.PubmedESearchResult;
+import reciter.pubmed.NcbiHttp;
 import reciter.pubmed.callable.PubMedUriParserCallable;
 import reciter.pubmed.querybuilder.PubmedXmlQuery;
 import reciter.pubmed.xmlparser.PubmedEFetchHandler;
@@ -87,7 +88,7 @@ public class PubMedArticleRetrievalService {
      * Initializes and starts threads that handles the retrieval process. Partition the number of articles
      * into manageable pieces and ask each thread to handle one partition.
      */
-    @Retryable(maxAttempts = 7, retryFor = RuntimeException.class, 
+    @Retryable(maxAttempts = 7, retryFor = { RuntimeException.class, IOException.class },
         backoff = @Backoff(random = true, delay = 1500, maxDelay = 9000), listeners = {"retryListener"})
 	public List<PubMedArticle> retrieve(String pubMedQuery) throws IOException {
 
@@ -209,46 +210,41 @@ public class PubMedArticleRetrievalService {
      *  - Retry happens ONLY when both conditions are true — same as original
      */
     private PubmedESearchResult executeRequestWithRetry(HttpRequest request, String query) throws IOException {
-        try {
-            NcbiRateLimiter.INSTANCE.acquire();
-            HttpResponse<InputStream> response = httpClient.send(request,
-                    HttpResponse.BodyHandlers.ofInputStream());
+        // NcbiHttp.sendWithRetry calls NcbiRateLimiter.INSTANCE.acquire() before every attempt
+        // (including retries) and retries a transient IOException (e.g. a pooled connection NCBI
+        // reset underneath us) instead of failing on the first attempt.
+        HttpResponse<InputStream> response = NcbiHttp.sendWithRetry(httpClient, request, 4);
 
-            // orElse(-1): absent header → -1 → block never triggers (matches original null/length guard)
-            int rateLimitRemaining = (int) response.headers()
-                    .firstValueAsLong("X-RateLimit-Remaining")
-                    .orElse(-1L);
+        // orElse(-1): absent header → -1 → block never triggers (matches original null/length guard)
+        int rateLimitRemaining = (int) response.headers()
+                .firstValueAsLong("X-RateLimit-Remaining")
+                .orElse(-1L);
 
-            log.info("Query: {} RateLimit-Remaining: {}", query, rateLimitRemaining);
+        log.info("Query: {} RateLimit-Remaining: {}", query, rateLimitRemaining);
 
-            if (rateLimitRemaining == 0) {
-                // Inner guard: only sleep+retry if Retry-After header is present
-                // matches: headerRetryAfter != null && length > 0 && headerRetryAfter[0] != null
-                OptionalLong retryAfter = response.headers().firstValueAsLong("Retry-After");
-                if (retryAfter.isPresent()) {
-                    long sleepSeconds = retryAfter.getAsLong();
-                    log.info("Rate limit hit. Query: {} Retry-After: {} seconds", query, sleepSeconds);
-                    try {
-                        Thread.sleep(sleepSeconds * 1000L);
-                    } catch (InterruptedException e) {
-                        Thread.currentThread().interrupt();
-                        log.error("InterruptedException during rate-limit pause", e);
-                    }
-                    // Retry only after confirmed sleep — matches original retry placement
-                    response = httpClient.send(request, HttpResponse.BodyHandlers.ofInputStream());
+        if (rateLimitRemaining == 0) {
+            // Inner guard: only sleep+retry if Retry-After header is present
+            // matches: headerRetryAfter != null && length > 0 && headerRetryAfter[0] != null
+            OptionalLong retryAfter = response.headers().firstValueAsLong("Retry-After");
+            if (retryAfter.isPresent()) {
+                long sleepSeconds = retryAfter.getAsLong();
+                log.info("Rate limit hit. Query: {} Retry-After: {} seconds", query, sleepSeconds);
+                try {
+                    Thread.sleep(sleepSeconds * 1000L);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    log.error("InterruptedException during rate-limit pause", e);
                 }
+                // Retry only after confirmed sleep — matches original retry placement
+                response = NcbiHttp.sendWithRetry(httpClient, request, 4);
             }
+        }
 
-            try (InputStream esearchStream = response.body()) {
-                JsonNode json = objectMapper.readTree(esearchStream).get("esearchresult");
-                if (json != null) {
-                    return objectMapper.treeToValue(json, PubmedESearchResult.class);
-                }
+        try (InputStream esearchStream = response.body()) {
+            JsonNode json = objectMapper.readTree(esearchStream).get("esearchresult");
+            if (json != null) {
+                return objectMapper.treeToValue(json, PubmedESearchResult.class);
             }
-
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new IOException("HTTP request interrupted for query=[" + query + "]", e);
         }
 
         return new PubmedESearchResult();

--- a/src/main/java/reciter/pubmed/xmlparser/PubmedESearchHandler.java
+++ b/src/main/java/reciter/pubmed/xmlparser/PubmedESearchHandler.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import reciter.model.pubmed.PubmedESearchResult;
+import reciter.pubmed.NcbiHttp;
 import reciter.pubmed.querybuilder.PubmedXmlQuery;
 
 /**
@@ -108,45 +109,41 @@ public class PubmedESearchHandler extends DefaultHandler {
      */
     private static PubmedESearchResult executeWithRateLimitHandling(
             HttpRequest request, String eSearchUrl, String fullUrl) throws IOException {
-        try {
-            HttpResponse<InputStream> response = HTTP_CLIENT.send(
-                    request, HttpResponse.BodyHandlers.ofInputStream());
+        // NcbiHttp.sendWithRetry calls NcbiRateLimiter.INSTANCE.acquire() before every attempt
+        // (including retries) and retries a transient IOException (e.g. a pooled connection NCBI
+        // reset underneath us) instead of failing on the first attempt.
+        HttpResponse<InputStream> response = NcbiHttp.sendWithRetry(HTTP_CLIENT, request, 4);
 
-            // orElse(-1): absent header → -1 → block never triggers (matches original null/length guard)
-            int rateLimitRemaining = (int) response.headers()
-                    .firstValueAsLong("X-RateLimit-Remaining")
-                    .orElse(-1L);
+        // orElse(-1): absent header → -1 → block never triggers (matches original null/length guard)
+        int rateLimitRemaining = (int) response.headers()
+                .firstValueAsLong("X-RateLimit-Remaining")
+                .orElse(-1L);
 
-            if (rateLimitRemaining == 0) {
-                // Inner guard: only sleep+retry if Retry-After header is present
-                // matches: headerRetryAfter != null && length > 0 && headerRetryAfter[0] != null
-                OptionalLong retryAfter = response.headers().firstValueAsLong("Retry-After");
-                if (retryAfter.isPresent()) {
-                    long sleepSeconds = retryAfter.getAsLong();
-                    log.info("Rate limit hit. eSearchUrl=[{}] Retry-After: {} seconds",
-                            eSearchUrl, sleepSeconds);
-                    try {
-                        Thread.sleep(sleepSeconds * 1000L);
-                    } catch (InterruptedException ie) {
-                        Thread.currentThread().interrupt();
-                        log.error("InterruptedException during rate-limit pause", ie);
-                    }
-                    // Retry only after confirmed sleep — matches original retry placement
-                    response = HTTP_CLIENT.send(request, HttpResponse.BodyHandlers.ofInputStream());
+        if (rateLimitRemaining == 0) {
+            // Inner guard: only sleep+retry if Retry-After header is present
+            // matches: headerRetryAfter != null && length > 0 && headerRetryAfter[0] != null
+            OptionalLong retryAfter = response.headers().firstValueAsLong("Retry-After");
+            if (retryAfter.isPresent()) {
+                long sleepSeconds = retryAfter.getAsLong();
+                log.info("Rate limit hit. eSearchUrl=[{}] Retry-After: {} seconds",
+                        eSearchUrl, sleepSeconds);
+                try {
+                    Thread.sleep(sleepSeconds * 1000L);
+                } catch (InterruptedException ie) {
+                    Thread.currentThread().interrupt();
+                    log.error("InterruptedException during rate-limit pause", ie);
                 }
+                // Retry only after confirmed sleep — matches original retry placement
+                response = NcbiHttp.sendWithRetry(HTTP_CLIENT, request, 4);
             }
+        }
 
-            // Parse esearchresult JSON from response body
-            try (InputStream esearchStream = response.body()) {
-                JsonNode json = OBJECT_MAPPER.readTree(esearchStream).get("esearchresult");
-                if (json != null) {
-                    return OBJECT_MAPPER.treeToValue(json, PubmedESearchResult.class);
-                }
+        // Parse esearchresult JSON from response body
+        try (InputStream esearchStream = response.body()) {
+            JsonNode json = OBJECT_MAPPER.readTree(esearchStream).get("esearchresult");
+            if (json != null) {
+                return OBJECT_MAPPER.treeToValue(json, PubmedESearchResult.class);
             }
-
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new IOException("HTTP request interrupted for eSearchUrl=[" + eSearchUrl + "]", e);
         }
 
         return new PubmedESearchResult();

--- a/src/test/java/reciter/pubmed/NcbiHttpTest.java
+++ b/src/test/java/reciter/pubmed/NcbiHttpTest.java
@@ -1,0 +1,196 @@
+package reciter.pubmed;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.Authenticator;
+import java.net.CookieHandler;
+import java.net.ProxySelector;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpHeaders;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLParameters;
+import javax.net.ssl.SSLSession;
+
+import org.junit.jupiter.api.Test;
+
+class NcbiHttpTest {
+
+    private static HttpRequest dummyRequest() {
+        return HttpRequest.newBuilder().uri(URI.create("https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi"))
+                .GET().build();
+    }
+
+    @Test
+    void retriesTransientIOExceptionThenSucceeds() throws Exception {
+        StubResponse okResponse = new StubResponse();
+        Deque<Object> script = new ArrayDeque<>();
+        script.add(new IOException("Connection reset"));
+        script.add(new IOException("Connection reset"));
+        script.add(okResponse);
+        ScriptedHttpClient client = new ScriptedHttpClient(script);
+
+        HttpResponse<InputStream> response = NcbiHttp.sendWithRetry(client, dummyRequest(), 4);
+
+        assertSame(okResponse, response);
+        assertEquals(3, client.sendCalls, "expected 2 failures + 1 success = 3 send() calls");
+    }
+
+    @Test
+    void rethrowsAfterExhaustingAttempts() {
+        Deque<Object> script = new ArrayDeque<>();
+        script.add(new IOException("Connection reset 1"));
+        script.add(new IOException("Connection reset 2"));
+        script.add(new IOException("Connection reset 3"));
+        script.add(new IOException("Connection reset 4"));
+        ScriptedHttpClient client = new ScriptedHttpClient(script);
+
+        IOException thrown = assertThrows(IOException.class,
+                () -> NcbiHttp.sendWithRetry(client, dummyRequest(), 4));
+
+        assertEquals("Connection reset 4", thrown.getMessage(), "should rethrow the LAST failure, not the first");
+        assertEquals(4, client.sendCalls, "expected exactly maxAttempts (4) send() calls, no more");
+    }
+
+    /**
+     * Minimal {@link HttpClient} stub whose {@code send(...)} replays a scripted sequence of
+     * outcomes (either throw the next queued {@link IOException}, or return the next queued
+     * {@link HttpResponse}). Only {@code send} is exercised by {@link NcbiHttp}; the remaining
+     * abstract methods are never called by the code under test and just return harmless defaults.
+     */
+    private static final class ScriptedHttpClient extends HttpClient {
+        private final Deque<Object> script;
+        int sendCalls = 0;
+
+        ScriptedHttpClient(Deque<Object> script) {
+            this.script = script;
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <T> HttpResponse<T> send(HttpRequest request, HttpResponse.BodyHandler<T> responseBodyHandler)
+                throws IOException, InterruptedException {
+            sendCalls++;
+            Object next = script.poll();
+            if (next instanceof IOException) {
+                throw (IOException) next;
+            }
+            return (HttpResponse<T>) next;
+        }
+
+        @Override
+        public <T> CompletableFuture<HttpResponse<T>> sendAsync(HttpRequest request,
+                HttpResponse.BodyHandler<T> responseBodyHandler) {
+            throw new UnsupportedOperationException("not used by NcbiHttp");
+        }
+
+        @Override
+        public <T> CompletableFuture<HttpResponse<T>> sendAsync(HttpRequest request,
+                HttpResponse.BodyHandler<T> responseBodyHandler,
+                HttpResponse.PushPromiseHandler<T> pushPromiseHandler) {
+            throw new UnsupportedOperationException("not used by NcbiHttp");
+        }
+
+        @Override
+        public Optional<CookieHandler> cookieHandler() {
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<Duration> connectTimeout() {
+            return Optional.empty();
+        }
+
+        @Override
+        public Redirect followRedirects() {
+            return Redirect.NEVER;
+        }
+
+        @Override
+        public Optional<ProxySelector> proxy() {
+            return Optional.empty();
+        }
+
+        @Override
+        public SSLContext sslContext() {
+            throw new UnsupportedOperationException("not used by NcbiHttp");
+        }
+
+        @Override
+        public SSLParameters sslParameters() {
+            return new SSLParameters();
+        }
+
+        @Override
+        public Optional<Authenticator> authenticator() {
+            return Optional.empty();
+        }
+
+        @Override
+        public Version version() {
+            return Version.HTTP_1_1;
+        }
+
+        @Override
+        public Optional<Executor> executor() {
+            return Optional.empty();
+        }
+    }
+
+    /** Minimal {@link HttpResponse} stub — only identity matters for these tests. */
+    private static final class StubResponse implements HttpResponse<InputStream> {
+        @Override
+        public int statusCode() {
+            return 200;
+        }
+
+        @Override
+        public HttpRequest request() {
+            return null;
+        }
+
+        @Override
+        public Optional<HttpResponse<InputStream>> previousResponse() {
+            return Optional.empty();
+        }
+
+        @Override
+        public HttpHeaders headers() {
+            return HttpHeaders.of(Map.of(), (a, b) -> true);
+        }
+
+        @Override
+        public InputStream body() {
+            return InputStream.nullInputStream();
+        }
+
+        @Override
+        public Optional<SSLSession> sslSession() {
+            return Optional.empty();
+        }
+
+        @Override
+        public URI uri() {
+            return URI.create("https://eutils.ncbi.nlm.nih.gov/");
+        }
+
+        @Override
+        public HttpClient.Version version() {
+            return HttpClient.Version.HTTP_1_1;
+        }
+    }
+}


### PR DESCRIPTION
## Why

Prod pods log `java.io.IOException: Connection reset` from eutils in bursts (101 lines / 11 "Retry exhausted" in 3 afternoon hours on 2026-09-01) — NCBI closes idle pooled connections and the next `java.net.http.HttpClient` send on that connection dies. Nothing retried it: `PubMedArticleRetrievalService.retrieve` is `@Retryable(retryFor = RuntimeException.class)`, which a checked `IOException` never matches ("Retry Count 1 → Retry exhausted" with zero real retries), and the controller's ESearch/count path and `PubmedESearchHandler` had no retry at all. Consequences today: intermittent empty PubMed searches in the Publication Manager, and — worse — dropped `GoldStandardRetrievalStrategy` batches that shrank a person's ESearchResult and Analysis (rharrington 763 → 374 accepted; see wcmc-its/ReCiter#737 for the engine-side guard).

## What

- `NcbiHttp.sendWithRetry(client, request, maxAttempts)` — retries a transient `IOException` (incl. `HttpTimeoutException`) up to 4 attempts, backoff 1.5 s × 2^(attempt−1) capped at 9 s, WARN per attempt; **`NcbiRateLimiter.INSTANCE.acquire()` before every attempt including retries**; rethrows the last failure. Used at all six send sites (controller ×2, `PubmedESearchHandler` ×2 — which previously never acquired the limiter at all — and `executeRequestWithRetry` ×2).
- `retrieve`: `retryFor = { RuntimeException.class, IOException.class }` (attempts/backoff/listener unchanged).
- `ReciterRetryListener`: exhausted log now carries the attempt count and exception class, so "gave up after 7" is distinguishable from "never retried".
- The `catch (InterruptedException)` wrappers at the converted sites became unreachable (the helper maps interrupts to `IOException`) and were removed with the wrapped logic kept intact.

## Verification

`mvn -o test`: baseline 2 tests → 4 tests, BUILD SUCCESS (new `NcbiHttpTest`: 2 resets then success = exactly 3 sends; 4 resets = rethrow, exactly 4 sends; hand-rolled HttpClient stub, no new dependencies, pom untouched). Rate-limit Retry-After handling, eutils URLs, and page sizes are unchanged (diffed). Worst case under a sustained outage compounds to 7 × 4 sends per query, each paced by the rate limiter — intentional.

Not exercised against live NCBI. After deploy, `kubectl logs -l app=reciter-pubmed-prod --tail=-1 | grep "attempt 2/"` should appear where "Retry exhausted" used to.