### PR TITLE
Redact the NCBI api_key from ESearch/EFetch log lines

### DIFF
--- a/src/main/java/reciter/controller/PubMedRetrievalToolController.java
+++ b/src/main/java/reciter/controller/PubMedRetrievalToolController.java
@@ -99,7 +99,7 @@ public class PubMedRetrievalToolController {
                 ? PubmedXmlQuery.ESEARCH_BASE_URL + "?api_key=" + pubmedXmlQuery.getApiKey()
                 : PubmedXmlQuery.ESEARCH_BASE_URL;
 
-        log.info("ESearch Query=[{}]", fullUrl);
+        log.info("ESearch Query=[{}]", PubmedXmlQuery.redactApiKey(fullUrl));
 
         // Build URL-encoded form body
         String formData = "db="         + URLEncoder.encode(pubmedXmlQuery.getDb(), StandardCharsets.UTF_8)

--- a/src/main/java/reciter/pubmed/querybuilder/PubmedXmlQuery.java
+++ b/src/main/java/reciter/pubmed/querybuilder/PubmedXmlQuery.java
@@ -1,5 +1,7 @@
 package reciter.pubmed.querybuilder;
 
+import java.util.regex.Pattern;
+
 import lombok.Data;
 
 /**
@@ -139,5 +141,22 @@ public class PubmedXmlQuery {
             return "?api_key=" + apiKey + "&";
         }
         return "?";
+    }
+
+    // ── Matches "api_key=<value>" where value is anything up to the next '&', whitespace, or ']' ──
+    private static final Pattern API_KEY_PATTERN = Pattern.compile("api_key=[^&\\s\\]]+");
+
+    /**
+     * Redacts the NCBI api_key value from a URL (or any string) for safe logging.
+     * Only for use in log statements — never on a URL/body actually sent to NCBI.
+     *
+     * @param url a URL or string that may contain "api_key=&lt;value&gt;"; may be null
+     * @return the same string with every api_key value replaced by "REDACTED"; null if input is null
+     */
+    public static String redactApiKey(String url) {
+        if (url == null) {
+            return null;
+        }
+        return API_KEY_PATTERN.matcher(url).replaceAll("api_key=REDACTED");
     }
 }

--- a/src/main/java/reciter/pubmed/retriever/PubMedArticleRetrievalService.java
+++ b/src/main/java/reciter/pubmed/retriever/PubMedArticleRetrievalService.java
@@ -123,13 +123,13 @@ public class PubMedArticleRetrievalService {
 			}
 
 			String eFetchUrl = pubmedXmlQuery.buildEFetchQuery();
-			log.info("eFetchUrl=[{}].", eFetchUrl);
+			log.info("eFetchUrl=[{}].", PubmedXmlQuery.redactApiKey(eFetchUrl));
 
 			try {
 				callables.add(new PubMedUriParserCallable(new PubmedEFetchHandler(), getSaxParser(),
 						new InputSource(eFetchUrl)));
 			} catch (ParserConfigurationException | SAXException e) {
-				log.error("Failed to create PubMedUriParserCallable for url=[{}]", eFetchUrl, e);
+				log.error("Failed to create PubMedUriParserCallable for url=[{}]", PubmedXmlQuery.redactApiKey(eFetchUrl), e);
 			}
 
 			currentRetStart += pubmedXmlQuery.getRetMax();
@@ -177,7 +177,7 @@ public class PubMedArticleRetrievalService {
                 ? PubmedXmlQuery.ESEARCH_BASE_URL + "?api_key=" + pubmedXmlQuery.getApiKey()
                 : PubmedXmlQuery.ESEARCH_BASE_URL;
 
-        log.info("ESearch Query=[{}]", fullUrl);
+        log.info("ESearch Query=[{}]", PubmedXmlQuery.redactApiKey(fullUrl));
 
         // Build URL-encoded form body — StandardCharsets.UTF_8 avoids checked exception
         String formData = "db=" + URLEncoder.encode(pubmedXmlQuery.getDb(), StandardCharsets.UTF_8)

--- a/src/main/java/reciter/pubmed/xmlparser/PubmedESearchHandler.java
+++ b/src/main/java/reciter/pubmed/xmlparser/PubmedESearchHandler.java
@@ -71,7 +71,7 @@ public class PubmedESearchHandler extends DefaultHandler {
 		String fullUrl = (pubmedXmlQuery.getApiKey() != null && !pubmedXmlQuery.getApiKey().isEmpty())
 				? PubmedXmlQuery.ESEARCH_BASE_URL + "?api_key=" + pubmedXmlQuery.getApiKey()
 				: PubmedXmlQuery.ESEARCH_BASE_URL;
-		log.info("ESearch Query=[{}]", fullUrl);
+		log.info("ESearch Query=[{}]", PubmedXmlQuery.redactApiKey(fullUrl));
 
 		// Build URL-encoded form body — StandardCharsets.UTF_8 avoids
 		// UnsupportedEncodingException
@@ -90,7 +90,7 @@ public class PubmedESearchHandler extends DefaultHandler {
 		try {
 			return executeWithRateLimitHandling(request, eSearchUrl, fullUrl);
 		} catch (IOException e) {
-			log.error("Error executing eSearch query=[{}], fullUrl=[{}]", eSearchUrl, fullUrl, e);
+			log.error("Error executing eSearch query=[{}], fullUrl=[{}]", eSearchUrl, PubmedXmlQuery.redactApiKey(fullUrl), e);
 		}
 
 		return new PubmedESearchResult();
@@ -124,7 +124,7 @@ public class PubmedESearchHandler extends DefaultHandler {
                 if (retryAfter.isPresent()) {
                     long sleepSeconds = retryAfter.getAsLong();
                     log.info("Rate limit hit. eSearchUrl=[{}] Retry-After: {} seconds",
-                            eSearchUrl, sleepSeconds);
+                            PubmedXmlQuery.redactApiKey(eSearchUrl), sleepSeconds);
                     try {
                         Thread.sleep(sleepSeconds * 1000L);
                     } catch (InterruptedException ie) {

--- a/src/test/java/reciter/pubmed/querybuilder/PubmedXmlQueryRedactTest.java
+++ b/src/test/java/reciter/pubmed/querybuilder/PubmedXmlQueryRedactTest.java
@@ -1,0 +1,45 @@
+package reciter.pubmed.querybuilder;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.Test;
+
+class PubmedXmlQueryRedactTest {
+
+    /** api_key in the middle of a query string is redacted; the rest of the string is untouched. */
+    @Test
+    void redactsKeyInMiddleOfQueryString() {
+        String url = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi?api_key=abc123&db=pubmed";
+
+        String redacted = PubmedXmlQuery.redactApiKey(url);
+
+        assertEquals("https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi?api_key=REDACTED&db=pubmed", redacted);
+    }
+
+    /** api_key at the end of the string (no trailing '&') is still fully redacted. */
+    @Test
+    void redactsKeyAtEndOfString() {
+        String url = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi?db=pubmed&api_key=abc123";
+
+        String redacted = PubmedXmlQuery.redactApiKey(url);
+
+        assertEquals("https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi?db=pubmed&api_key=REDACTED", redacted);
+    }
+
+    /** A URL with no api_key parameter is returned unchanged. */
+    @Test
+    void urlWithoutKeyIsUnchanged() {
+        String url = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi?db=pubmed&term=Kukafka%20R[au]";
+
+        String redacted = PubmedXmlQuery.redactApiKey(url);
+
+        assertEquals(url, redacted);
+    }
+
+    /** Null input returns null — must not throw. */
+    @Test
+    void nullInputReturnsNull() {
+        assertNull(PubmedXmlQuery.redactApiKey(null));
+    }
+}


### PR DESCRIPTION
Every ESearch and EFetch request logs the full NCBI URL at INFO, which includes the `api_key` value, so the key sits in clear text in the prod pod logs.

## Change
- `PubmedXmlQuery.redactApiKey(String)`: replaces every `api_key=<value>` with `api_key=REDACTED`; null-safe.
- Applied to every log statement that prints a URL that can carry the key: `PubMedRetrievalToolController` (ESearch), `PubmedESearchHandler` (ESearch, error, rate-limit lines), `PubMedArticleRetrievalService` (ESearch and EFetch lines). Only log arguments changed; the URLs and bodies sent to NCBI are byte-identical.
- Unit test with four cases (key mid-string, key at end, no key, null).

## Verification
- `mvn -o test`: 2 → 6 tests, 0 failures.
- Independent fresh-context review of the full diff: PASS. One pre-existing LOW it noted for a follow-up: on the EFetch path an `HttpURLConnection` error message embeds the full URL, and that exception is logged with its stack trace in `PubMedArticleRetrievalService`, so the key can still appear there on an EFetch HTTP error.

Independent of #174 (different lines); either merge order works.